### PR TITLE
Complete Rust bot feature parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn.lock
 # Claude Code artifacts
 CLAUDE.md
 .claude/
+.serena/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+CosmoClerk is a Rust 2021 Telegram bot for Cosmos chain-registry lookups. Source lives in `src/`: `main.rs` loads `.env` and starts the bot, `bot.rs` owns the Teloxide dialogue state machine, `handlers.rs` contains message/callback flows, `cache.rs` wraps chain data with a 30-minute TTL, `utils.rs` holds HTTP/IBC/Osmosis helpers, and `commands.rs` defines slash commands. Tests currently live in `src/tests.rs`. `README_RUST.md` documents setup, and `cosmoclerk.service` is the systemd deployment example. Legacy JS/TS code belongs only on isolated archive branches; keep Node package artifacts out of the Rust branch.
+
+## Build, Test, and Development Commands
+- `cp .env.example .env` then set `BOT_TOKEN` before running locally.
+- `cargo check` validates Rust types quickly.
+- `RUST_LOG=debug cargo run` starts the bot with verbose logging.
+- `cargo build --release` creates `target/release/cosmoclerk` for deployment.
+- `cargo test` runs the async unit tests in `src/tests.rs`.
+- `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` are the preferred pre-PR style and lint gates.
+
+## Coding Style & Naming Conventions
+Follow rustfmt defaults with 4-space indentation. Use `snake_case` for functions, modules, variables, and tests; use `CamelCase` for types, enum variants, and structs. Keep async I/O on Tokio; avoid blocking calls in handlers or dispatcher paths. Reuse existing helpers for MarkdownV2 escaping, endpoint fallback, cache access, and callback data parsing before adding new utilities.
+
+## Testing Guidelines
+Use `#[tokio::test]` for async behavior. Name tests `test_<behavior>` and prefer deterministic tests for state transitions, callback parsing, chain filtering, keyboard layout, and formatter helpers. Avoid tests that require a real Telegram token or live chain endpoint unless isolated behind explicit setup notes.
+
+## Commit & Pull Request Guidelines
+Recent history uses short, lower-case imperative subjects, for example `add wallet balance check feature for mainnets` and `fix testnet listing and add ABCI info to chain details`. PR descriptions should explain user-visible bot changes, list verification commands, and note any `.env.example`, systemd, or deployment impact. Include screenshots or Telegram transcript snippets for UI/menu changes when practical.
+
+## Security & Configuration Tips
+Never commit real bot tokens or chat/user identifiers. Keep local secrets in untracked `.env`; update `.env.example` only for safe variable names/defaults.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Osmosis pool addresses, specific incentives details, translating `ibc/...` denom
 - choose from one of the menu options<br>
 <br>
 more options to be added:<br>
-- wallet balances<br>
 - smart contract query<br>
 - more<br>
 Please make a detailed issue. contributions also welcome.

--- a/README_RUST.md
+++ b/README_RUST.md
@@ -8,22 +8,23 @@ A Rust implementation of the CosmoClerk Telegram bot using the [chain-registry-r
 - **Built-in Caching**: 30-minute TTL cache reduces API calls and improves response times (~50µs cached vs ~500ms network)
 - **Type Safety**: Rust's strong typing ensures data integrity
 - **Lower Memory Footprint**: No need to store entire registry locally
-# Built-in Caching: 30-minute TTL cache reduces API calls and improves response times
-- **Built-in Caching**: 30-minute TTL cache reduces API calls and improves response times (~50µs cached vs ~500ms network)
 
 ## Features
 
-All features from the original JS version are supported:
+Core bot features:
 
 -  Chain selection with pagination
 -  Chain info display (ID, name, RPC, REST, etc.)
 -  Peer nodes listing
--  Endpoints display (RPC, REST, GRPC)
+-  Endpoints display (RPC, REST, GRPC, EVM RPC where available)
 -  Block explorers
 -  IBC denomination lookup
+-  IBC route lookup by channel
+-  Wallet balance lookup with IBC denom resolution
+-  Polkachu node installation guide links for supported chains
 -  Osmosis-specific features:
-  - Pool incentives
   - Pool info
+  - LP incentive gauges and concentrated liquidity incentive records
   - Price info
 
 ## Setup
@@ -68,6 +69,8 @@ cargo fmt
 - `src/cache.rs` - Registry data caching layer
 - `src/utils.rs` - Helper functions
 - `src/commands.rs` - Bot command definitions
+
+Legacy JavaScript/TypeScript versions are archived on isolated branches. The active `main` line is the Rust rewrite and should stay free of Node package artifacts.
 
 ## Dependencies
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "node-fetch": "^3.3.2",
-    "simple-git": "^3.21.0",
-    "telegraf": "^4.15.3",
-  }
-}

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -29,6 +29,10 @@ pub enum State {
         chain: String,
         message_id: Option<teloxide::types::MessageId>,
     },
+    AwaitingWalletAddress {
+        chain: String,
+        message_id: Option<teloxide::types::MessageId>,
+    },
 }
 
 pub async fn run(bot: Bot) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -60,6 +64,7 @@ fn schema() -> UpdateHandler<Box<dyn std::error::Error + Send + Sync + 'static>>
         .branch(command_handler)
         .branch(case![State::AwaitingIbcDenom { chain, message_id }].endpoint(handlers::handle_ibc_denom))
         .branch(case![State::AwaitingIbcChannel { chain, message_id }].endpoint(handlers::handle_ibc_channel))
+        .branch(case![State::AwaitingWalletAddress { chain, message_id }].endpoint(handlers::handle_wallet_address))
         .branch(dptree::endpoint(handlers::handle_text));
 
     let callback_handler = Update::filter_callback_query()
@@ -67,6 +72,7 @@ fn schema() -> UpdateHandler<Box<dyn std::error::Error + Send + Sync + 'static>>
         .branch(case![State::ChainSelected { chain, message_id }].endpoint(handlers::handle_chain_action))
         .branch(case![State::AwaitingIbcDenom { chain, message_id }].endpoint(handlers::handle_chain_action))
         .branch(case![State::AwaitingIbcChannel { chain, message_id }].endpoint(handlers::handle_chain_action))
+        .branch(case![State::AwaitingWalletAddress { chain, message_id }].endpoint(handlers::handle_chain_action))
         .branch(case![State::Start].endpoint(handlers::handle_callback))
         .branch(dptree::endpoint(handlers::handle_callback));
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -33,6 +33,18 @@ pub enum State {
         chain: String,
         message_id: Option<teloxide::types::MessageId>,
     },
+    AwaitingOsmosisPoolIncentives {
+        chain: String,
+        message_id: Option<teloxide::types::MessageId>,
+    },
+    AwaitingOsmosisPoolInfo {
+        chain: String,
+        message_id: Option<teloxide::types::MessageId>,
+    },
+    AwaitingOsmosisTokenTicker {
+        chain: String,
+        message_id: Option<teloxide::types::MessageId>,
+    },
 }
 
 pub async fn run(bot: Bot) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -62,17 +74,70 @@ fn schema() -> UpdateHandler<Box<dyn std::error::Error + Send + Sync + 'static>>
 
     let message_handler = Update::filter_message()
         .branch(command_handler)
-        .branch(case![State::AwaitingIbcDenom { chain, message_id }].endpoint(handlers::handle_ibc_denom))
-        .branch(case![State::AwaitingIbcChannel { chain, message_id }].endpoint(handlers::handle_ibc_channel))
-        .branch(case![State::AwaitingWalletAddress { chain, message_id }].endpoint(handlers::handle_wallet_address))
+        .branch(
+            case![State::AwaitingIbcDenom { chain, message_id }]
+                .endpoint(handlers::handle_ibc_denom),
+        )
+        .branch(
+            case![State::AwaitingIbcChannel { chain, message_id }]
+                .endpoint(handlers::handle_ibc_channel),
+        )
+        .branch(
+            case![State::AwaitingWalletAddress { chain, message_id }]
+                .endpoint(handlers::handle_wallet_address),
+        )
+        .branch(
+            case![State::AwaitingOsmosisPoolIncentives { chain, message_id }]
+                .endpoint(handlers::handle_osmosis_pool_incentives),
+        )
+        .branch(
+            case![State::AwaitingOsmosisPoolInfo { chain, message_id }]
+                .endpoint(handlers::handle_osmosis_pool_info),
+        )
+        .branch(
+            case![State::AwaitingOsmosisTokenTicker { chain, message_id }]
+                .endpoint(handlers::handle_osmosis_token_price),
+        )
         .branch(dptree::endpoint(handlers::handle_text));
 
     let callback_handler = Update::filter_callback_query()
-        .branch(case![State::SelectingChain { page, is_testnet, message_id, last_selected_chain }].endpoint(handlers::handle_chain_selection))
-        .branch(case![State::ChainSelected { chain, message_id }].endpoint(handlers::handle_chain_action))
-        .branch(case![State::AwaitingIbcDenom { chain, message_id }].endpoint(handlers::handle_chain_action))
-        .branch(case![State::AwaitingIbcChannel { chain, message_id }].endpoint(handlers::handle_chain_action))
-        .branch(case![State::AwaitingWalletAddress { chain, message_id }].endpoint(handlers::handle_chain_action))
+        .branch(
+            case![State::SelectingChain {
+                page,
+                is_testnet,
+                message_id,
+                last_selected_chain
+            }]
+            .endpoint(handlers::handle_chain_selection),
+        )
+        .branch(
+            case![State::ChainSelected { chain, message_id }]
+                .endpoint(handlers::handle_chain_action),
+        )
+        .branch(
+            case![State::AwaitingIbcDenom { chain, message_id }]
+                .endpoint(handlers::handle_chain_action),
+        )
+        .branch(
+            case![State::AwaitingIbcChannel { chain, message_id }]
+                .endpoint(handlers::handle_chain_action),
+        )
+        .branch(
+            case![State::AwaitingWalletAddress { chain, message_id }]
+                .endpoint(handlers::handle_chain_action),
+        )
+        .branch(
+            case![State::AwaitingOsmosisPoolIncentives { chain, message_id }]
+                .endpoint(handlers::handle_chain_action),
+        )
+        .branch(
+            case![State::AwaitingOsmosisPoolInfo { chain, message_id }]
+                .endpoint(handlers::handle_chain_action),
+        )
+        .branch(
+            case![State::AwaitingOsmosisTokenTicker { chain, message_id }]
+                .endpoint(handlers::handle_chain_action),
+        )
         .branch(case![State::Start].endpoint(handlers::handle_callback))
         .branch(dptree::endpoint(handlers::handle_callback));
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -40,7 +40,7 @@ impl RegistryCache {
         let chain = cosmos_chain_registry::get::get_chain(name)
             .await
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        
+
         // If not found, try testnets
         let chain = if chain.is_none() {
             cosmos_chain_registry::get::get_chain(&format!("testnets/{}", name))
@@ -49,7 +49,7 @@ impl RegistryCache {
         } else {
             chain
         };
-        
+
         if let Some(ref c) = chain {
             self.chains.insert(
                 name.to_string(),
@@ -77,7 +77,7 @@ impl RegistryCache {
         let assets = cosmos_chain_registry::get::get_assets(name)
             .await
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        
+
         // If not found, try testnets
         let assets = if assets.is_none() {
             cosmos_chain_registry::get::get_assets(&format!("testnets/{}", name))
@@ -86,7 +86,7 @@ impl RegistryCache {
         } else {
             assets
         };
-        
+
         if let Some(ref a) = assets {
             self.assets.insert(
                 name.to_string(),
@@ -98,7 +98,6 @@ impl RegistryCache {
         }
         Ok(assets)
     }
-
 
     pub async fn list_chains(&self) -> anyhow::Result<Vec<String>> {
         // Check cache first
@@ -115,12 +114,10 @@ impl RegistryCache {
         let chains = cosmos_chain_registry::get::list_chains()
             .await
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        
+
         // Filter out the testnets directory itself
-        let chains: Vec<String> = chains.into_iter()
-            .filter(|c| c != "testnets")
-            .collect();
-        
+        let chains: Vec<String> = chains.into_iter().filter(|c| c != "testnets").collect();
+
         self.chain_list.insert(
             "mainnets".to_string(),
             CachedItem {
@@ -128,10 +125,10 @@ impl RegistryCache {
                 timestamp: Instant::now(),
             },
         );
-        
+
         Ok(chains)
     }
-    
+
     pub async fn list_testnets(&self) -> anyhow::Result<Vec<String>> {
         // Check cache first
         if let Some(cached) = self.chain_list.get("testnets") {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,10 @@
 use teloxide::utils::command::BotCommands;
 
 #[derive(BotCommands, Clone)]
-#[command(rename_rule = "lowercase", description = "These commands are supported:")]
+#[command(
+    rename_rule = "lowercase",
+    description = "These commands are supported:"
+)]
 pub enum Command {
     #[command(description = "Start the bot")]
     Start,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,16 +1,20 @@
 use crate::{
     bot::{MyDialogue, State},
     cache::RegistryCache,
-    utils::{escape_markdown, find_healthy_endpoint, find_healthy_rest_endpoint,
-            query_ibc_denom, query_ibc_denom_with_fallback, query_ibc_channel_info_with_fallback,
-            extract_channel_from_path, format_channel_input, query_abci_info,
-            get_polkachu_installation_url, query_balances_with_fallback, format_amount,
-            truncate_ibc_hash, PAGE_SIZE},
+    utils::{
+        escape_markdown, extract_channel_from_path, find_healthy_endpoint,
+        find_healthy_rest_endpoint, format_amount, format_channel_input,
+        format_osmosis_pool_incentives, format_osmosis_pool_info, format_osmosis_token_price,
+        get_polkachu_installation_url, query_abci_info, query_balances_with_fallback,
+        query_ibc_channel_info_with_fallback, query_ibc_denom, query_ibc_denom_with_fallback,
+        query_osmosis_pool_incentives, query_osmosis_pool_info, query_osmosis_token_price,
+        truncate_ibc_hash, PAGE_SIZE,
+    },
 };
 use std::sync::Arc;
 use teloxide::{
     prelude::*,
-    types::{InlineKeyboardButton, InlineKeyboardMarkup, ParseMode, MessageId},
+    types::{InlineKeyboardButton, InlineKeyboardMarkup, MessageId, ParseMode},
 };
 
 pub async fn start(
@@ -19,12 +23,14 @@ pub async fn start(
     cache: Arc<RegistryCache>,
     msg: Message,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    dialogue.update(State::SelectingChain { 
-        page: 0, 
-        is_testnet: false, 
-        message_id: None, 
-        last_selected_chain: None 
-    }).await?;
+    dialogue
+        .update(State::SelectingChain {
+            page: 0,
+            is_testnet: false,
+            message_id: None,
+            last_selected_chain: None,
+        })
+        .await?;
     show_chain_selection(&bot, &msg, &cache, 0, false, None).await?;
     Ok(())
 }
@@ -39,10 +45,7 @@ pub async fn restart(
     start(bot, dialogue, cache, msg).await
 }
 
-pub async fn help(
-    bot: Bot,
-    msg: Message,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+pub async fn help(bot: Bot, msg: Message) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     bot.send_message(
         msg.chat.id,
         "CosmoClerk Bot - Cosmos Chain Registry Explorer\n\n\
@@ -62,12 +65,14 @@ pub async fn show_testnets(
     cache: Arc<RegistryCache>,
     msg: Message,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    dialogue.update(State::SelectingChain { 
-        page: 0, 
-        is_testnet: true, 
-        message_id: None,
-        last_selected_chain: None 
-    }).await?;
+    dialogue
+        .update(State::SelectingChain {
+            page: 0,
+            is_testnet: true,
+            message_id: None,
+            last_selected_chain: None,
+        })
+        .await?;
     show_chain_selection(&bot, &msg, &cache, 0, true, None).await?;
     Ok(())
 }
@@ -78,12 +83,14 @@ pub async fn show_mainnets(
     cache: Arc<RegistryCache>,
     msg: Message,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    dialogue.update(State::SelectingChain { 
-        page: 0, 
-        is_testnet: false, 
-        message_id: None,
-        last_selected_chain: None 
-    }).await?;
+    dialogue
+        .update(State::SelectingChain {
+            page: 0,
+            is_testnet: false,
+            message_id: None,
+            last_selected_chain: None,
+        })
+        .await?;
     show_chain_selection(&bot, &msg, &cache, 0, false, None).await?;
     Ok(())
 }
@@ -102,18 +109,18 @@ async fn show_chain_selection(
         cache.list_chains().await?
     };
 
-    let total_pages = (filtered_chains.len() + PAGE_SIZE - 1) / PAGE_SIZE;
+    let total_pages = filtered_chains.len().div_ceil(PAGE_SIZE);
     let start = page * PAGE_SIZE;
     let end = (start + PAGE_SIZE).min(filtered_chains.len());
-    
+
     let page_chains = &filtered_chains[start..end];
-    
+
     let mut buttons = vec![];
     for chunk in page_chains.chunks(3) {
         let row: Vec<InlineKeyboardButton> = chunk
             .iter()
             .map(|chain| {
-                let display_name = if last_selected.map_or(false, |s| s == chain) {
+                let display_name = if last_selected == Some(chain) {
                     format!("🔴 {}", chain)
                 } else {
                     chain.clone()
@@ -123,34 +130,41 @@ async fn show_chain_selection(
             .collect();
         buttons.push(row);
     }
-    
+
     // Navigation buttons
     let mut nav_buttons = vec![];
     if page > 0 {
-        nav_buttons.push(InlineKeyboardButton::callback("← Previous", format!("page:{}", page - 1)));
+        nav_buttons.push(InlineKeyboardButton::callback(
+            "← Previous",
+            format!("page:{}", page - 1),
+        ));
     }
     if page < total_pages - 1 {
-        nav_buttons.push(InlineKeyboardButton::callback("Next →", format!("page:{}", page + 1)));
+        nav_buttons.push(InlineKeyboardButton::callback(
+            "Next →",
+            format!("page:{}", page + 1),
+        ));
     }
     if !nav_buttons.is_empty() {
         buttons.push(nav_buttons);
     }
-    
+
     // Testnet toggle
     buttons.push(vec![InlineKeyboardButton::callback(
-        if is_testnet { "Show Mainnets" } else { "Show Testnets" },
+        if is_testnet {
+            "Show Mainnets"
+        } else {
+            "Show Testnets"
+        },
         format!("toggle_testnet:{}", !is_testnet),
     )]);
-    
+
     let keyboard = InlineKeyboardMarkup::new(buttons);
-    
-    bot.send_message(
-        msg.chat.id,
-        "Type a chain name, or select from menu:",
-    )
-    .reply_markup(keyboard)
-    .await?;
-    
+
+    bot.send_message(msg.chat.id, "Type a chain name, or select from menu:")
+        .reply_markup(keyboard)
+        .await?;
+
     Ok(())
 }
 
@@ -159,7 +173,12 @@ pub async fn handle_chain_selection(
     dialogue: MyDialogue,
     cache: Arc<RegistryCache>,
     q: CallbackQuery,
-    (_page, is_testnet, _message_id, last_selected_chain): (usize, bool, Option<teloxide::types::MessageId>, Option<String>),
+    (_page, is_testnet, _message_id, last_selected_chain): (
+        usize,
+        bool,
+        Option<teloxide::types::MessageId>,
+        Option<String>,
+    ),
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(ref data) = q.data {
         if let Some(chain) = data.strip_prefix("select:") {
@@ -171,33 +190,47 @@ pub async fn handle_chain_selection(
                 }
             }
             let new_menu_id = show_chain_menu(&bot, &q, &chain).await?;
-            dialogue.update(State::ChainSelected { 
-                chain: chain.clone(), 
-                message_id: Some(new_menu_id) 
-            }).await?;
+            dialogue
+                .update(State::ChainSelected {
+                    chain: chain.clone(),
+                    message_id: Some(new_menu_id),
+                })
+                .await?;
         } else if let Some(page_str) = data.strip_prefix("page:") {
             let new_page: usize = page_str.parse()?;
             let msg_id = q.message.as_ref().map(|m| m.id);
-            dialogue.update(State::SelectingChain { 
-                page: new_page, 
+            dialogue
+                .update(State::SelectingChain {
+                    page: new_page,
+                    is_testnet,
+                    message_id: msg_id,
+                    last_selected_chain: last_selected_chain.clone(),
+                })
+                .await?;
+            update_chain_selection(
+                &bot,
+                &q,
+                &cache,
+                new_page,
                 is_testnet,
-                message_id: msg_id,
-                last_selected_chain: last_selected_chain.clone()
-            }).await?;
-            update_chain_selection(&bot, &q, &cache, new_page, is_testnet, last_selected_chain.as_ref()).await?;
+                last_selected_chain.as_ref(),
+            )
+            .await?;
         } else if let Some(testnet_str) = data.strip_prefix("toggle_testnet:") {
             let new_testnet: bool = testnet_str.parse()?;
             let msg_id = q.message.as_ref().map(|m| m.id);
-            dialogue.update(State::SelectingChain { 
-                page: 0, 
-                is_testnet: new_testnet,
-                message_id: msg_id,
-                last_selected_chain: None
-            }).await?;
+            dialogue
+                .update(State::SelectingChain {
+                    page: 0,
+                    is_testnet: new_testnet,
+                    message_id: msg_id,
+                    last_selected_chain: None,
+                })
+                .await?;
             update_chain_selection(&bot, &q, &cache, 0, new_testnet, None).await?;
         }
     }
-    
+
     bot.answer_callback_query(q.id).await?;
     Ok(())
 }
@@ -216,18 +249,18 @@ async fn update_chain_selection(
         cache.list_chains().await?
     };
 
-    let total_pages = (filtered_chains.len() + PAGE_SIZE - 1) / PAGE_SIZE;
+    let total_pages = filtered_chains.len().div_ceil(PAGE_SIZE);
     let start = page * PAGE_SIZE;
     let end = (start + PAGE_SIZE).min(filtered_chains.len());
-    
+
     let page_chains = &filtered_chains[start..end];
-    
+
     let mut buttons = vec![];
     for chunk in page_chains.chunks(3) {
         let row: Vec<InlineKeyboardButton> = chunk
             .iter()
             .map(|chain| {
-                let display_name = if last_selected.map_or(false, |s| s == chain) {
+                let display_name = if last_selected == Some(chain) {
                     format!("🔴 {}", chain)
                 } else {
                     chain.clone()
@@ -237,35 +270,50 @@ async fn update_chain_selection(
             .collect();
         buttons.push(row);
     }
-    
+
     // Navigation buttons
     let mut nav_buttons = vec![];
     if page > 0 {
-        nav_buttons.push(InlineKeyboardButton::callback("← Previous", format!("page:{}", page - 1)));
+        nav_buttons.push(InlineKeyboardButton::callback(
+            "← Previous",
+            format!("page:{}", page - 1),
+        ));
     }
     if page < total_pages - 1 {
-        nav_buttons.push(InlineKeyboardButton::callback("Next →", format!("page:{}", page + 1)));
+        nav_buttons.push(InlineKeyboardButton::callback(
+            "Next →",
+            format!("page:{}", page + 1),
+        ));
     }
     if !nav_buttons.is_empty() {
         buttons.push(nav_buttons);
     }
-    
+
     // Testnet toggle
     buttons.push(vec![InlineKeyboardButton::callback(
-        if is_testnet { "Show Mainnets" } else { "Show Testnets" },
+        if is_testnet {
+            "Show Mainnets"
+        } else {
+            "Show Testnets"
+        },
         format!("toggle_testnet:{}", !is_testnet),
     )]);
-    
+
     let keyboard = InlineKeyboardMarkup::new(buttons);
-    
+
     edit_callback_message_with_markup(
         bot,
         q,
-        if is_testnet { "Select a testnet:" } else { "Select a chain:" }.to_string(),
+        if is_testnet {
+            "Select a testnet:"
+        } else {
+            "Select a chain:"
+        }
+        .to_string(),
         keyboard,
     )
     .await?;
-    
+
     Ok(())
 }
 
@@ -296,6 +344,21 @@ async fn edit_callback_message_with_markup(
     Ok(())
 }
 
+fn is_osmosis_mainnet(chain: &str) -> bool {
+    chain.eq_ignore_ascii_case("osmosis")
+}
+
+fn push_osmosis_buttons(buttons: &mut Vec<Vec<InlineKeyboardButton>>) {
+    buttons.push(vec![
+        InlineKeyboardButton::callback("8. LP Incentives", "action:pool_incentives"),
+        InlineKeyboardButton::callback("9. Pool Info", "action:pool_info"),
+    ]);
+    buttons.push(vec![InlineKeyboardButton::callback(
+        "10. Price Info",
+        "action:price_info",
+    )]);
+}
+
 async fn show_chain_menu(
     bot: &Bot,
     q: &CallbackQuery,
@@ -318,28 +381,39 @@ async fn show_chain_menu(
             InlineKeyboardButton::callback("5. IBC-ID", "action:ibc_id"),
             InlineKeyboardButton::callback("6. IBC Route Info", "action:ibc_route"),
         ]);
-        buttons.push(vec![
-            InlineKeyboardButton::callback("7. Check Balance", "action:check_balance"),
-        ]);
+        buttons.push(vec![InlineKeyboardButton::callback(
+            "7. Check Balance",
+            "action:check_balance",
+        )]);
+        if is_osmosis_mainnet(chain) {
+            push_osmosis_buttons(&mut buttons);
+        }
     }
 
     // Add installation guide link if available on Polkachu
     if let Some(install_url) = get_polkachu_installation_url(chain) {
-        buttons.push(vec![InlineKeyboardButton::url("Node Installation Guide", install_url.parse().unwrap())]);
+        buttons.push(vec![InlineKeyboardButton::url(
+            "Node Installation Guide",
+            install_url.parse().unwrap(),
+        )]);
     }
 
-    buttons.push(vec![InlineKeyboardButton::callback("← Back", "back:chains")]);
+    buttons.push(vec![InlineKeyboardButton::callback(
+        "← Back",
+        "back:chains",
+    )]);
 
     let keyboard = InlineKeyboardMarkup::new(buttons);
 
     // Send as a new message instead of editing
     if let Some(Message { chat, .. }) = &q.message {
-        let sent_msg = bot.send_message(chat.id, format!("Selected: {}\n\nChoose an action:", chain))
+        let sent_msg = bot
+            .send_message(chat.id, format!("Selected: {}\n\nChoose an action:", chain))
             .reply_markup(keyboard)
             .await?;
         return Ok(sent_msg.id);
     }
-    
+
     Err("No message in callback query".into())
 }
 
@@ -350,16 +424,13 @@ async fn delete_message_with_effect(
     message_id: MessageId,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // First update the message with a vaporizing effect
-    let effects = vec![
-        "💨 ᵈⁱˢˢᵒˡᵛⁱⁿᵍ...",
-        "✨ ...",
-    ];
-    
+    let effects = vec!["💨 ᵈⁱˢˢᵒˡᵛⁱⁿᵍ...", "✨ ..."];
+
     for effect in effects {
         bot.edit_message_text(chat_id, message_id, effect).await?;
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     }
-    
+
     // Then delete the message
     bot.delete_message(chat_id, message_id).await?;
     Ok(())
@@ -388,30 +459,40 @@ async fn send_chain_menu(
             InlineKeyboardButton::callback("5. IBC-ID", "action:ibc_id"),
             InlineKeyboardButton::callback("6. IBC Route Info", "action:ibc_route"),
         ]);
-        buttons.push(vec![
-            InlineKeyboardButton::callback("7. Check Balance", "action:check_balance"),
-        ]);
+        buttons.push(vec![InlineKeyboardButton::callback(
+            "7. Check Balance",
+            "action:check_balance",
+        )]);
+        if is_osmosis_mainnet(chain) {
+            push_osmosis_buttons(&mut buttons);
+        }
     }
 
     // Add installation guide link if available on Polkachu
     if let Some(install_url) = get_polkachu_installation_url(chain) {
-        buttons.push(vec![InlineKeyboardButton::url("Node Installation Guide", install_url.parse().unwrap())]);
+        buttons.push(vec![InlineKeyboardButton::url(
+            "Node Installation Guide",
+            install_url.parse().unwrap(),
+        )]);
     }
 
-    buttons.push(vec![InlineKeyboardButton::callback("← Back", "back:chains")]);
+    buttons.push(vec![InlineKeyboardButton::callback(
+        "← Back",
+        "back:chains",
+    )]);
 
     let keyboard = InlineKeyboardMarkup::new(buttons);
 
-    let sent_msg = bot.send_message(
-        msg.chat.id,
-        format!("Selected: {}\n\nChoose an action:", chain),
-    )
-    .reply_markup(keyboard)
-    .await?;
+    let sent_msg = bot
+        .send_message(
+            msg.chat.id,
+            format!("Selected: {}\n\nChoose an action:", chain),
+        )
+        .reply_markup(keyboard)
+        .await?;
 
     Ok(sent_msg.id)
 }
-
 
 pub async fn handle_chain_action(
     bot: Bot,
@@ -431,10 +512,12 @@ pub async fn handle_chain_action(
                 show_chain_info(&bot, &q, &cache, &chain).await?;
                 // Show menu again after displaying info
                 let new_menu_id = show_chain_menu(&bot, &q, &chain).await?;
-                dialogue.update(State::ChainSelected { 
-                    chain: chain.clone(), 
-                    message_id: Some(new_menu_id) 
-                }).await?;
+                dialogue
+                    .update(State::ChainSelected {
+                        chain: chain.clone(),
+                        message_id: Some(new_menu_id),
+                    })
+                    .await?;
             }
             "action:peer_nodes" => {
                 // Delete the menu with effect
@@ -445,10 +528,12 @@ pub async fn handle_chain_action(
                 show_peer_nodes(&bot, &q, &cache, &chain).await?;
                 // Show menu again after displaying info
                 let new_menu_id = show_chain_menu(&bot, &q, &chain).await?;
-                dialogue.update(State::ChainSelected { 
-                    chain: chain.clone(), 
-                    message_id: Some(new_menu_id) 
-                }).await?;
+                dialogue
+                    .update(State::ChainSelected {
+                        chain: chain.clone(),
+                        message_id: Some(new_menu_id),
+                    })
+                    .await?;
             }
             "action:endpoints" => {
                 // Delete the menu with effect
@@ -459,10 +544,12 @@ pub async fn handle_chain_action(
                 show_endpoints(&bot, &q, &cache, &chain).await?;
                 // Show menu again after displaying info
                 let new_menu_id = show_chain_menu(&bot, &q, &chain).await?;
-                dialogue.update(State::ChainSelected { 
-                    chain: chain.clone(), 
-                    message_id: Some(new_menu_id) 
-                }).await?;
+                dialogue
+                    .update(State::ChainSelected {
+                        chain: chain.clone(),
+                        message_id: Some(new_menu_id),
+                    })
+                    .await?;
             }
             "action:explorers" => {
                 // Delete the menu with effect
@@ -473,17 +560,24 @@ pub async fn handle_chain_action(
                 show_explorers(&bot, &q, &cache, &chain).await?;
                 // Show menu again after displaying info
                 let new_menu_id = show_chain_menu(&bot, &q, &chain).await?;
-                dialogue.update(State::ChainSelected { 
-                    chain: chain.clone(), 
-                    message_id: Some(new_menu_id) 
-                }).await?;
+                dialogue
+                    .update(State::ChainSelected {
+                        chain: chain.clone(),
+                        message_id: Some(new_menu_id),
+                    })
+                    .await?;
             }
             "action:ibc_id" => {
                 // Delete the menu with effect
                 if let Some(Message { id, chat, .. }) = &q.message {
                     delete_message_with_effect(&bot, chat.id, *id).await?;
                     let msg_id = q.message.as_ref().map(|m| m.id);
-                    dialogue.update(State::AwaitingIbcDenom { chain, message_id: msg_id }).await?;
+                    dialogue
+                        .update(State::AwaitingIbcDenom {
+                            chain,
+                            message_id: msg_id,
+                        })
+                        .await?;
                     bot.send_message(chat.id, "Enter IBC denom (e.g., ibc/ABC123...):")
                         .await?;
                 }
@@ -493,7 +587,12 @@ pub async fn handle_chain_action(
                 if let Some(Message { id, chat, .. }) = &q.message {
                     delete_message_with_effect(&bot, chat.id, *id).await?;
                     let msg_id = q.message.as_ref().map(|m| m.id);
-                    dialogue.update(State::AwaitingIbcChannel { chain, message_id: msg_id }).await?;
+                    dialogue
+                        .update(State::AwaitingIbcChannel {
+                            chain,
+                            message_id: msg_id,
+                        })
+                        .await?;
                     bot.send_message(chat.id, "Enter IBC channel (e.g., 0 or channel-0):\nOptionally add port (e.g., channel-0 transfer):")
                         .await?;
                 }
@@ -503,26 +602,90 @@ pub async fn handle_chain_action(
                 if let Some(Message { id, chat, .. }) = &q.message {
                     delete_message_with_effect(&bot, chat.id, *id).await?;
                     let msg_id = q.message.as_ref().map(|m| m.id);
-                    dialogue.update(State::AwaitingWalletAddress { chain, message_id: msg_id }).await?;
+                    dialogue
+                        .update(State::AwaitingWalletAddress {
+                            chain,
+                            message_id: msg_id,
+                        })
+                        .await?;
                     bot.send_message(chat.id, "Enter wallet address to check balance:")
                         .await?;
+                }
+            }
+            "action:pool_incentives" => {
+                if let Some(Message { id, chat, .. }) = &q.message {
+                    delete_message_with_effect(&bot, chat.id, *id).await?;
+                    if is_osmosis_mainnet(&chain) {
+                        let msg_id = q.message.as_ref().map(|m| m.id);
+                        dialogue
+                            .update(State::AwaitingOsmosisPoolIncentives {
+                                chain,
+                                message_id: msg_id,
+                            })
+                            .await?;
+                        bot.send_message(chat.id, "Enter Osmosis pool ID for LP incentives:")
+                            .await?;
+                    } else {
+                        bot.send_message(chat.id, "LP incentives are only available for Osmosis.")
+                            .await?;
+                    }
+                }
+            }
+            "action:pool_info" => {
+                if let Some(Message { id, chat, .. }) = &q.message {
+                    delete_message_with_effect(&bot, chat.id, *id).await?;
+                    if is_osmosis_mainnet(&chain) {
+                        let msg_id = q.message.as_ref().map(|m| m.id);
+                        dialogue
+                            .update(State::AwaitingOsmosisPoolInfo {
+                                chain,
+                                message_id: msg_id,
+                            })
+                            .await?;
+                        bot.send_message(chat.id, "Enter Osmosis pool ID for pool info:")
+                            .await?;
+                    } else {
+                        bot.send_message(chat.id, "Pool info is only available for Osmosis.")
+                            .await?;
+                    }
+                }
+            }
+            "action:price_info" => {
+                if let Some(Message { id, chat, .. }) = &q.message {
+                    delete_message_with_effect(&bot, chat.id, *id).await?;
+                    if is_osmosis_mainnet(&chain) {
+                        let msg_id = q.message.as_ref().map(|m| m.id);
+                        dialogue
+                            .update(State::AwaitingOsmosisTokenTicker {
+                                chain,
+                                message_id: msg_id,
+                            })
+                            .await?;
+                        bot.send_message(chat.id, "Enter Osmosis token symbol or base denom:")
+                            .await?;
+                    } else {
+                        bot.send_message(chat.id, "Price info is only available for Osmosis.")
+                            .await?;
+                    }
                 }
             }
             "back:chains" => {
                 // No need to delete - update_chain_selection will edit the existing message
                 let msg_id = q.message.as_ref().map(|m| m.id);
-                dialogue.update(State::SelectingChain { 
-                    page: 0, 
-                    is_testnet: false,
-                    message_id: msg_id,
-                    last_selected_chain: Some(chain.clone())
-                }).await?;
+                dialogue
+                    .update(State::SelectingChain {
+                        page: 0,
+                        is_testnet: false,
+                        message_id: msg_id,
+                        last_selected_chain: Some(chain.clone()),
+                    })
+                    .await?;
                 update_chain_selection(&bot, &q, &cache, 0, false, Some(&chain)).await?;
             }
             _ => {}
         }
     }
-    
+
     bot.answer_callback_query(q.id).await?;
     Ok(())
 }
@@ -535,7 +698,7 @@ async fn show_chain_info(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let chain_data = cache.get_chain(chain).await?;
     let assets_data = cache.get_assets(chain).await?;
-    
+
     if let (Some(chain_info), Some(assets)) = (chain_data, assets_data) {
         let base_denom = chain_info
             .staking
@@ -617,7 +780,7 @@ async fn show_chain_info(
     } else {
         send_callback_message(bot, q, format!("Chain {} not found", chain)).await?;
     }
-    
+
     Ok(())
 }
 
@@ -628,10 +791,10 @@ async fn show_peer_nodes(
     chain: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let chain_data = cache.get_chain(chain).await?;
-    
+
     if let Some(chain_info) = chain_data {
         let mut message = String::from("*Seed Nodes*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n");
-        
+
         for seed in chain_info.peers.seeds.iter().take(5) {
             let provider = seed.provider.as_deref().unwrap_or("unknown");
             message.push_str(&format!(
@@ -641,9 +804,9 @@ async fn show_peer_nodes(
                 escape_markdown(&seed.address)
             ));
         }
-        
+
         message.push_str("\n*Persistent Peers*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n");
-        
+
         for peer in chain_info.peers.persistent_peers.iter().take(5) {
             message.push_str(&format!(
                 "id: `{}`\nURL: `{}`\n\n",
@@ -651,7 +814,7 @@ async fn show_peer_nodes(
                 escape_markdown(&peer.address)
             ));
         }
-        
+
         // Send as new message instead of editing
         if let Some(Message { chat, .. }) = &q.message {
             bot.send_message(chat.id, message)
@@ -661,7 +824,7 @@ async fn show_peer_nodes(
     } else {
         send_callback_message(bot, q, format!("Chain {} not found", chain)).await?;
     }
-    
+
     Ok(())
 }
 
@@ -672,10 +835,10 @@ async fn show_endpoints(
     chain: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let chain_data = cache.get_chain(chain).await?;
-    
+
     if let Some(chain_info) = chain_data {
         let mut message = String::from("*RPC*\n\\-\\-\\-\n");
-        
+
         for rpc in chain_info.apis.rpc.iter().take(5) {
             let provider = rpc.provider.as_deref().unwrap_or("unknown");
             message.push_str(&format!(
@@ -684,9 +847,9 @@ async fn show_endpoints(
                 escape_markdown(&rpc.address)
             ));
         }
-        
+
         message.push_str("\n*REST*\n\\-\\-\\-\\-\n");
-        
+
         for rest in chain_info.apis.rest.iter().take(5) {
             let provider = rest.provider.as_deref().unwrap_or("unknown");
             message.push_str(&format!(
@@ -695,7 +858,7 @@ async fn show_endpoints(
                 escape_markdown(&rest.address)
             ));
         }
-        
+
         message.push_str("\n*GRPC*\n\\-\\-\\-\\-\n");
 
         for grpc in chain_info.apis.grpc.iter().take(5) {
@@ -729,7 +892,7 @@ async fn show_endpoints(
     } else {
         send_callback_message(bot, q, format!("Chain {} not found", chain)).await?;
     }
-    
+
     Ok(())
 }
 
@@ -740,10 +903,11 @@ async fn show_explorers(
     chain: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let chain_data = cache.get_chain(chain).await?;
-    
+
     if let Some(chain_info) = chain_data {
-        let mut message = String::from("*Block Explorers*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n\n");
-        
+        let mut message =
+            String::from("*Block Explorers*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n\n");
+
         for explorer in &chain_info.explorers {
             message.push_str(&format!(
                 "*{}*:\n`{}`\n\n",
@@ -751,7 +915,7 @@ async fn show_explorers(
                 escape_markdown(&explorer.url)
             ));
         }
-        
+
         // Send as new message instead of editing
         if let Some(Message { chat, .. }) = &q.message {
             bot.send_message(chat.id, message)
@@ -761,7 +925,7 @@ async fn show_explorers(
     } else {
         send_callback_message(bot, q, format!("Chain {} not found", chain)).await?;
     }
-    
+
     Ok(())
 }
 
@@ -774,30 +938,44 @@ pub async fn handle_ibc_denom(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(text) = msg.text() {
         if let Some(ibc_hash) = text.strip_prefix("ibc/") {
-            
             // Get chain info to find REST endpoint
             if let Some(chain_info) = cache.get_chain(&chain).await? {
                 match query_ibc_denom_with_fallback(&chain_info.apis.rest, ibc_hash).await {
                     Ok((path, base_denom)) => {
                         let mut message = if !path.is_empty() {
-                            format!("✅ IBC Denom Trace Found:\n\nPath: {}\nBase Denomination: {}", path, base_denom)
+                            format!(
+                                "✅ IBC Denom Trace Found:\n\nPath: {}\nBase Denomination: {}",
+                                path, base_denom
+                            )
                         } else {
-                            format!("✅ IBC Denom Trace Found:\n\nBase Denomination: {}", base_denom)
+                            format!(
+                                "✅ IBC Denom Trace Found:\n\nBase Denomination: {}",
+                                base_denom
+                            )
                         };
 
                         // Try to extract channel from path and fetch route info
                         if !path.is_empty() {
                             if let Some(channel) = extract_channel_from_path(&path) {
-                                match query_ibc_channel_info_with_fallback(&chain_info.apis.rest, &channel, "transfer").await {
+                                match query_ibc_channel_info_with_fallback(
+                                    &chain_info.apis.rest,
+                                    &channel,
+                                    "transfer",
+                                )
+                                .await
+                                {
                                     Ok(info) => {
                                         message.push_str(&format!(
                                             "\n\n📍 **Source Chain:** {}\n(via {})",
-                                            info.counterparty_chain_id,
-                                            channel
+                                            info.counterparty_chain_id, channel
                                         ));
                                     }
                                     Err(e) => {
-                                        log::warn!("Could not fetch channel info for {}: {}", channel, e);
+                                        log::warn!(
+                                            "Could not fetch channel info for {}: {}",
+                                            channel,
+                                            e
+                                        );
                                     }
                                 }
                             }
@@ -817,20 +995,28 @@ pub async fn handle_ibc_denom(
                 bot.send_message(msg.chat.id, "Chain not found").await?;
             }
         } else {
-            bot.send_message(msg.chat.id, "Please enter a valid IBC denom (e.g., ibc/ABC123...)").await?;
+            bot.send_message(
+                msg.chat.id,
+                "Please enter a valid IBC denom (e.g., ibc/ABC123...)",
+            )
+            .await?;
         }
-        
+
         // Show the menu after showing IBC info
         let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-        dialogue.update(State::ChainSelected { 
-            chain: chain.clone(), 
-            message_id: Some(new_menu_id) 
-        }).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain: chain.clone(),
+                message_id: Some(new_menu_id),
+            })
+            .await?;
     } else {
-        dialogue.update(State::ChainSelected { 
-            chain, 
-            message_id: None 
-        }).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain,
+                message_id: None,
+            })
+            .await?;
     }
     Ok(())
 }
@@ -844,26 +1030,34 @@ pub async fn handle_ibc_channel(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(text) = msg.text() {
         // Parse the input - could be "23", "channel-23", or "channel-23 transfer"
-        let parts: Vec<&str> = text.trim().split_whitespace().collect();
-        let channel_input = parts.get(0).unwrap_or(&"");
+        let parts: Vec<&str> = text.split_whitespace().collect();
+        let channel_input = parts.first().unwrap_or(&"");
         let port_id = parts.get(1).unwrap_or(&"transfer");
 
         let channel_id = format_channel_input(channel_input);
 
         // Validate channel format
         if !channel_id.starts_with("channel-") {
-            bot.send_message(msg.chat.id, "Please enter a valid channel (e.g., 0, channel-0)").await?;
+            bot.send_message(
+                msg.chat.id,
+                "Please enter a valid channel (e.g., 0, channel-0)",
+            )
+            .await?;
             let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-            dialogue.update(State::ChainSelected {
-                chain: chain.clone(),
-                message_id: Some(new_menu_id)
-            }).await?;
+            dialogue
+                .update(State::ChainSelected {
+                    chain: chain.clone(),
+                    message_id: Some(new_menu_id),
+                })
+                .await?;
             return Ok(());
         }
 
         // Get chain info to find REST endpoints
         if let Some(chain_info) = cache.get_chain(&chain).await? {
-            match query_ibc_channel_info_with_fallback(&chain_info.apis.rest, &channel_id, port_id).await {
+            match query_ibc_channel_info_with_fallback(&chain_info.apis.rest, &channel_id, port_id)
+                .await
+            {
                 Ok(info) => {
                     let message = format!(
                         "✅ IBC Route Information\n\n\
@@ -905,15 +1099,19 @@ pub async fn handle_ibc_channel(
 
         // Show the menu after showing IBC route info
         let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-        dialogue.update(State::ChainSelected {
-            chain: chain.clone(),
-            message_id: Some(new_menu_id)
-        }).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain: chain.clone(),
+                message_id: Some(new_menu_id),
+            })
+            .await?;
     } else {
-        dialogue.update(State::ChainSelected {
-            chain,
-            message_id: None
-        }).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain,
+                message_id: None,
+            })
+            .await?;
     }
     Ok(())
 }
@@ -930,12 +1128,15 @@ pub async fn handle_wallet_address(
 
         // Basic validation
         if address.is_empty() || address.len() < 10 || address.len() > 100 {
-            bot.send_message(msg.chat.id, "Please enter a valid wallet address.").await?;
+            bot.send_message(msg.chat.id, "Please enter a valid wallet address.")
+                .await?;
             let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-            dialogue.update(State::ChainSelected {
-                chain: chain.clone(),
-                message_id: Some(new_menu_id)
-            }).await?;
+            dialogue
+                .update(State::ChainSelected {
+                    chain: chain.clone(),
+                    message_id: Some(new_menu_id),
+                })
+                .await?;
             return Ok(());
         }
 
@@ -960,9 +1161,15 @@ pub async fn handle_wallet_address(
                             let display_denom = if bal.denom.starts_with("ibc/") {
                                 // Try to resolve IBC denom
                                 let ibc_hash = bal.denom.strip_prefix("ibc/").unwrap_or(&bal.denom);
-                                match query_ibc_denom_with_fallback(&chain_info.apis.rest, ibc_hash).await {
+                                match query_ibc_denom_with_fallback(&chain_info.apis.rest, ibc_hash)
+                                    .await
+                                {
                                     Ok((_path, base_denom)) => {
-                                        format!("{} \\({}\\)", escape_markdown(&base_denom), escape_markdown(&truncate_ibc_hash(&bal.denom)))
+                                        format!(
+                                            "{} \\({}\\)",
+                                            escape_markdown(&base_denom),
+                                            escape_markdown(&truncate_ibc_hash(&bal.denom))
+                                        )
                                     }
                                     Err(_) => escape_markdown(&bal.denom),
                                 }
@@ -1015,15 +1222,168 @@ pub async fn handle_wallet_address(
 
         // Show the menu after showing balance info
         let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-        dialogue.update(State::ChainSelected {
-            chain: chain.clone(),
-            message_id: Some(new_menu_id)
-        }).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain: chain.clone(),
+                message_id: Some(new_menu_id),
+            })
+            .await?;
     } else {
-        dialogue.update(State::ChainSelected {
-            chain,
-            message_id: None
-        }).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain,
+                message_id: None,
+            })
+            .await?;
+    }
+    Ok(())
+}
+
+fn parse_pool_id(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.parse::<u64>().is_ok() {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+pub async fn handle_osmosis_pool_incentives(
+    bot: Bot,
+    dialogue: MyDialogue,
+    cache: Arc<RegistryCache>,
+    msg: Message,
+    (chain, _message_id): (String, Option<MessageId>),
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(text) = msg.text() {
+        let Some(pool_id) = parse_pool_id(text) else {
+            bot.send_message(msg.chat.id, "Please enter a numeric Osmosis pool ID.")
+                .await?;
+            let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
+            dialogue
+                .update(State::ChainSelected {
+                    chain: chain.clone(),
+                    message_id: Some(new_menu_id),
+                })
+                .await?;
+            return Ok(());
+        };
+
+        if let Some(chain_info) = cache.get_chain(&chain).await? {
+            match query_osmosis_pool_incentives(&chain_info.apis.rest, &pool_id).await {
+                Ok(incentives) => {
+                    bot.send_message(
+                        msg.chat.id,
+                        format_osmosis_pool_incentives(&pool_id, &incentives),
+                    )
+                    .await?;
+                }
+                Err(e) => {
+                    bot.send_message(
+                        msg.chat.id,
+                        format!("Could not fetch Osmosis pool incentives: {e}"),
+                    )
+                    .await?;
+                }
+            }
+        } else {
+            bot.send_message(msg.chat.id, "Osmosis chain info not found.")
+                .await?;
+        }
+
+        let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain: chain.clone(),
+                message_id: Some(new_menu_id),
+            })
+            .await?;
+    }
+    Ok(())
+}
+
+pub async fn handle_osmosis_pool_info(
+    bot: Bot,
+    dialogue: MyDialogue,
+    cache: Arc<RegistryCache>,
+    msg: Message,
+    (chain, _message_id): (String, Option<MessageId>),
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(text) = msg.text() {
+        let Some(pool_id) = parse_pool_id(text) else {
+            bot.send_message(msg.chat.id, "Please enter a numeric Osmosis pool ID.")
+                .await?;
+            let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
+            dialogue
+                .update(State::ChainSelected {
+                    chain: chain.clone(),
+                    message_id: Some(new_menu_id),
+                })
+                .await?;
+            return Ok(());
+        };
+
+        if let Some(chain_info) = cache.get_chain(&chain).await? {
+            match query_osmosis_pool_info(&chain_info.apis.rest, &pool_id).await {
+                Ok(pool) => {
+                    bot.send_message(msg.chat.id, format_osmosis_pool_info(&pool_id, &pool))
+                        .await?;
+                }
+                Err(e) => {
+                    bot.send_message(msg.chat.id, format!("Could not fetch Osmosis pool: {e}"))
+                        .await?;
+                }
+            }
+        } else {
+            bot.send_message(msg.chat.id, "Osmosis chain info not found.")
+                .await?;
+        }
+
+        let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain: chain.clone(),
+                message_id: Some(new_menu_id),
+            })
+            .await?;
+    }
+    Ok(())
+}
+
+pub async fn handle_osmosis_token_price(
+    bot: Bot,
+    dialogue: MyDialogue,
+    msg: Message,
+    (chain, _message_id): (String, Option<MessageId>),
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(text) = msg.text() {
+        let token = text.trim();
+        if token.is_empty() {
+            bot.send_message(
+                msg.chat.id,
+                "Please enter an Osmosis token symbol or base denom.",
+            )
+            .await?;
+        } else {
+            match query_osmosis_token_price(token).await {
+                Ok(price) => {
+                    bot.send_message(msg.chat.id, format_osmosis_token_price(&price))
+                        .await?;
+                }
+                Err(e) => {
+                    bot.send_message(msg.chat.id, format!("Could not fetch Osmosis price: {e}"))
+                        .await?;
+                }
+            }
+        }
+
+        let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
+        dialogue
+            .update(State::ChainSelected {
+                chain: chain.clone(),
+                message_id: Some(new_menu_id),
+            })
+            .await?;
     }
     Ok(())
 }
@@ -1042,7 +1402,7 @@ pub async fn handle_text(
             let state = dialogue.get().await?.unwrap_or_default();
             match state {
                 State::ChainSelected { chain, message_id } => {
-                    let actions = if !chain.contains("testnet") {
+                    let mut actions = if !chain.contains("testnet") {
                         vec![
                             "chain_info",
                             "peer_nodes",
@@ -1053,17 +1413,15 @@ pub async fn handle_text(
                             "check_balance",
                         ]
                     } else {
-                        vec![
-                            "chain_info",
-                            "peer_nodes",
-                            "endpoints",
-                            "explorers",
-                        ]
+                        vec!["chain_info", "peer_nodes", "endpoints", "explorers"]
                     };
+                    if is_osmosis_mainnet(&chain) {
+                        actions.extend(["pool_incentives", "pool_info", "price_info"]);
+                    }
 
                     if num > 0 && num <= actions.len() {
                         let action = actions[num - 1];
-                        
+
                         // Delete the previous menu if it exists
                         if let Some(menu_id) = message_id {
                             if let Err(e) = bot.delete_message(msg.chat.id, menu_id).await {
@@ -1071,13 +1429,14 @@ pub async fn handle_text(
                                 eprintln!("Failed to delete menu: {}", e);
                             }
                         }
-                        
+
                         match action {
                             "chain_info" => {
                                 let chain_data = cache.get_chain(&chain).await?;
                                 let assets_data = cache.get_assets(&chain).await?;
 
-                                if let (Some(chain_info), Some(assets)) = (chain_data, assets_data) {
+                                if let (Some(chain_info), Some(assets)) = (chain_data, assets_data)
+                                {
                                     let base_denom = chain_info
                                         .staking
                                         .staking_tokens
@@ -1153,24 +1512,33 @@ pub async fn handle_text(
                                         .parse_mode(ParseMode::MarkdownV2)
                                         .await?;
                                 } else {
-                                    bot.send_message(msg.chat.id, format!("Chain {} not found", chain)).await?;
+                                    bot.send_message(
+                                        msg.chat.id,
+                                        format!("Chain {} not found", chain),
+                                    )
+                                    .await?;
                                 }
                                 // Show menu again
                                 let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-                                dialogue.update(State::ChainSelected { 
-                                    chain: chain.clone(), 
-                                    message_id: Some(new_menu_id) 
-                                }).await?;
+                                dialogue
+                                    .update(State::ChainSelected {
+                                        chain: chain.clone(),
+                                        message_id: Some(new_menu_id),
+                                    })
+                                    .await?;
                             }
                             "peer_nodes" => {
                                 // Show peer nodes directly
                                 let chain_data = cache.get_chain(&chain).await?;
-                                
+
                                 if let Some(chain_info) = chain_data {
-                                    let mut message = String::from("*Seed Nodes*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n");
-                                    
+                                    let mut message = String::from(
+                                        "*Seed Nodes*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n",
+                                    );
+
                                     for seed in chain_info.peers.seeds.iter().take(5) {
-                                        let provider = seed.provider.as_deref().unwrap_or("unknown");
+                                        let provider =
+                                            seed.provider.as_deref().unwrap_or("unknown");
                                         message.push_str(&format!(
                                             "*{}*:\nid: `{}`\nURL: `{}`\n\n",
                                             escape_markdown(provider),
@@ -1178,9 +1546,9 @@ pub async fn handle_text(
                                             escape_markdown(&seed.address)
                                         ));
                                     }
-                                    
+
                                     message.push_str("\n*Persistent Peers*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n");
-                                    
+
                                     for peer in chain_info.peers.persistent_peers.iter().take(5) {
                                         message.push_str(&format!(
                                             "id: `{}`\nURL: `{}`\n\n",
@@ -1188,27 +1556,33 @@ pub async fn handle_text(
                                             escape_markdown(&peer.address)
                                         ));
                                     }
-                                    
+
                                     bot.send_message(msg.chat.id, message)
                                         .parse_mode(ParseMode::MarkdownV2)
                                         .await?;
                                 } else {
-                                    bot.send_message(msg.chat.id, format!("Chain {} not found", chain)).await?;
+                                    bot.send_message(
+                                        msg.chat.id,
+                                        format!("Chain {} not found", chain),
+                                    )
+                                    .await?;
                                 }
                                 // Show menu again
                                 let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-                                dialogue.update(State::ChainSelected { 
-                                    chain: chain.clone(), 
-                                    message_id: Some(new_menu_id) 
-                                }).await?;
+                                dialogue
+                                    .update(State::ChainSelected {
+                                        chain: chain.clone(),
+                                        message_id: Some(new_menu_id),
+                                    })
+                                    .await?;
                             }
                             "endpoints" => {
                                 // Show endpoints directly
                                 let chain_data = cache.get_chain(&chain).await?;
-                                
+
                                 if let Some(chain_info) = chain_data {
                                     let mut message = String::from("*RPC*\n\\-\\-\\-\n");
-                                    
+
                                     for rpc in chain_info.apis.rpc.iter().take(5) {
                                         let provider = rpc.provider.as_deref().unwrap_or("unknown");
                                         message.push_str(&format!(
@@ -1217,22 +1591,24 @@ pub async fn handle_text(
                                             escape_markdown(&rpc.address)
                                         ));
                                     }
-                                    
+
                                     message.push_str("\n*REST*\n\\-\\-\\-\\-\n");
-                                    
+
                                     for rest in chain_info.apis.rest.iter().take(5) {
-                                        let provider = rest.provider.as_deref().unwrap_or("unknown");
+                                        let provider =
+                                            rest.provider.as_deref().unwrap_or("unknown");
                                         message.push_str(&format!(
                                             "*{}*:\n`{}`\n\n",
                                             escape_markdown(provider),
                                             escape_markdown(&rest.address)
                                         ));
                                     }
-                                    
+
                                     message.push_str("\n*GRPC*\n\\-\\-\\-\\-\n");
 
                                     for grpc in chain_info.apis.grpc.iter().take(5) {
-                                        let provider = grpc.provider.as_deref().unwrap_or("unknown");
+                                        let provider =
+                                            grpc.provider.as_deref().unwrap_or("unknown");
                                         message.push_str(&format!(
                                             "*{}*:\n`{}`\n\n",
                                             escape_markdown(provider),
@@ -1243,8 +1619,11 @@ pub async fn handle_text(
                                     if !chain_info.apis.evm_http_jsonrpc.is_empty() {
                                         message.push_str("\n*EVM RPC*\n\\-\\-\\-\\-\\-\\-\\-\\-\n");
 
-                                        for evm_rpc in chain_info.apis.evm_http_jsonrpc.iter().take(5) {
-                                            let provider = evm_rpc.provider.as_deref().unwrap_or("unknown");
+                                        for evm_rpc in
+                                            chain_info.apis.evm_http_jsonrpc.iter().take(5)
+                                        {
+                                            let provider =
+                                                evm_rpc.provider.as_deref().unwrap_or("unknown");
                                             message.push_str(&format!(
                                                 "*{}*:\n`{}`\n\n",
                                                 escape_markdown(provider),
@@ -1257,22 +1636,28 @@ pub async fn handle_text(
                                         .parse_mode(ParseMode::MarkdownV2)
                                         .await?;
                                 } else {
-                                    bot.send_message(msg.chat.id, format!("Chain {} not found", chain)).await?;
+                                    bot.send_message(
+                                        msg.chat.id,
+                                        format!("Chain {} not found", chain),
+                                    )
+                                    .await?;
                                 }
                                 // Show menu again
                                 let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-                                dialogue.update(State::ChainSelected { 
-                                    chain: chain.clone(), 
-                                    message_id: Some(new_menu_id) 
-                                }).await?;
+                                dialogue
+                                    .update(State::ChainSelected {
+                                        chain: chain.clone(),
+                                        message_id: Some(new_menu_id),
+                                    })
+                                    .await?;
                             }
                             "explorers" => {
                                 // Show explorers directly
                                 let chain_data = cache.get_chain(&chain).await?;
-                                
+
                                 if let Some(chain_info) = chain_data {
                                     let mut message = String::from("*Block Explorers*\n\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\\-\n\n");
-                                    
+
                                     for explorer in &chain_info.explorers {
                                         message.push_str(&format!(
                                             "*{}*:\n`{}`\n\n",
@@ -1280,36 +1665,105 @@ pub async fn handle_text(
                                             escape_markdown(&explorer.url)
                                         ));
                                     }
-                                    
+
                                     bot.send_message(msg.chat.id, message)
                                         .parse_mode(ParseMode::MarkdownV2)
                                         .await?;
                                 } else {
-                                    bot.send_message(msg.chat.id, format!("Chain {} not found", chain)).await?;
+                                    bot.send_message(
+                                        msg.chat.id,
+                                        format!("Chain {} not found", chain),
+                                    )
+                                    .await?;
                                 }
                                 // Show menu again
                                 let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-                                dialogue.update(State::ChainSelected { 
-                                    chain: chain.clone(), 
-                                    message_id: Some(new_menu_id) 
-                                }).await?;
+                                dialogue
+                                    .update(State::ChainSelected {
+                                        chain: chain.clone(),
+                                        message_id: Some(new_menu_id),
+                                    })
+                                    .await?;
                             }
                             "ibc_id" => {
-                                dialogue.update(State::AwaitingIbcDenom { chain, message_id: Some(msg.id) }).await?;
-                                bot.send_message(msg.chat.id, "Enter IBC denom (e.g., ibc/ABC123...):").await?;
+                                dialogue
+                                    .update(State::AwaitingIbcDenom {
+                                        chain,
+                                        message_id: Some(msg.id),
+                                    })
+                                    .await?;
+                                bot.send_message(
+                                    msg.chat.id,
+                                    "Enter IBC denom (e.g., ibc/ABC123...):",
+                                )
+                                .await?;
                             }
                             "ibc_route" => {
-                                dialogue.update(State::AwaitingIbcChannel { chain, message_id: Some(msg.id) }).await?;
+                                dialogue
+                                    .update(State::AwaitingIbcChannel {
+                                        chain,
+                                        message_id: Some(msg.id),
+                                    })
+                                    .await?;
                                 bot.send_message(msg.chat.id, "Enter IBC channel (e.g., 0 or channel-0):\nOptionally add port (e.g., channel-0 transfer):").await?;
                             }
                             "check_balance" => {
-                                dialogue.update(State::AwaitingWalletAddress { chain, message_id: Some(msg.id) }).await?;
-                                bot.send_message(msg.chat.id, "Enter wallet address to check balance:").await?;
+                                dialogue
+                                    .update(State::AwaitingWalletAddress {
+                                        chain,
+                                        message_id: Some(msg.id),
+                                    })
+                                    .await?;
+                                bot.send_message(
+                                    msg.chat.id,
+                                    "Enter wallet address to check balance:",
+                                )
+                                .await?;
+                            }
+                            "pool_incentives" => {
+                                dialogue
+                                    .update(State::AwaitingOsmosisPoolIncentives {
+                                        chain,
+                                        message_id: Some(msg.id),
+                                    })
+                                    .await?;
+                                bot.send_message(
+                                    msg.chat.id,
+                                    "Enter Osmosis pool ID for LP incentives:",
+                                )
+                                .await?;
+                            }
+                            "pool_info" => {
+                                dialogue
+                                    .update(State::AwaitingOsmosisPoolInfo {
+                                        chain,
+                                        message_id: Some(msg.id),
+                                    })
+                                    .await?;
+                                bot.send_message(
+                                    msg.chat.id,
+                                    "Enter Osmosis pool ID for pool info:",
+                                )
+                                .await?;
+                            }
+                            "price_info" => {
+                                dialogue
+                                    .update(State::AwaitingOsmosisTokenTicker {
+                                        chain,
+                                        message_id: Some(msg.id),
+                                    })
+                                    .await?;
+                                bot.send_message(
+                                    msg.chat.id,
+                                    "Enter Osmosis token symbol or base denom:",
+                                )
+                                .await?;
                             }
                             _ => {}
                         }
                     } else {
-                        bot.send_message(msg.chat.id, "Invalid option number. Please try again.").await?;
+                        bot.send_message(msg.chat.id, "Invalid option number. Please try again.")
+                            .await?;
                     }
                 }
                 _ => {
@@ -1322,25 +1776,28 @@ pub async fn handle_text(
             }
             return Ok(());
         }
-        
+
         // Handle direct IBC denom input
         if text_lower.starts_with("ibc/") {
             // Get current state to find the selected chain
             let state = dialogue.get().await?.unwrap_or_default();
             match state {
-                State::ChainSelected { chain, .. } | 
-                State::AwaitingIbcDenom { chain, .. } => {
+                State::ChainSelected { chain, .. } | State::AwaitingIbcDenom { chain, .. } => {
                     let ibc_hash = &text[4..]; // Remove "ibc/" prefix
-                    
+
                     // Get chain info to find REST endpoint
                     if let Some(chain_info) = cache.get_chain(&chain).await? {
-                        if let Some(rest) = find_healthy_rest_endpoint(&chain_info.apis.rest).await {
+                        if let Some(rest) = find_healthy_rest_endpoint(&chain_info.apis.rest).await
+                        {
                             match query_ibc_denom(&rest, ibc_hash).await {
                                 Ok((path, base_denom)) => {
                                     let message = if !path.is_empty() {
                                         format!("✅ IBC Denom Trace Found:\n\nPath: {}\nBase Denomination: {}", path, base_denom)
                                     } else {
-                                        format!("✅ IBC Denom Trace Found:\n\nBase Denomination: {}", base_denom)
+                                        format!(
+                                            "✅ IBC Denom Trace Found:\n\nBase Denomination: {}",
+                                            base_denom
+                                        )
                                     };
                                     bot.send_message(msg.chat.id, message).await?;
                                 }
@@ -1349,26 +1806,27 @@ pub async fn handle_text(
                                         "❌ Could not resolve IBC denom:\n{}\n\nThis denom might not exist on {} or the chain's REST API might be unavailable.",
                                         e, chain
                                     );
-                                    bot.send_message(
-                                        msg.chat.id,
-                                        error_message,
-                                    )
-                                    .await?;
+                                    bot.send_message(msg.chat.id, error_message).await?;
                                 }
                             }
                         } else {
-                            bot.send_message(msg.chat.id, "No healthy REST endpoint found for this chain")
-                                .await?;
+                            bot.send_message(
+                                msg.chat.id,
+                                "No healthy REST endpoint found for this chain",
+                            )
+                            .await?;
                         }
                     } else {
                         bot.send_message(msg.chat.id, "Chain not found").await?;
                     }
                     // Show menu again after IBC lookup
                     let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
-                    dialogue.update(State::ChainSelected { 
-                        chain: chain.clone(), 
-                        message_id: Some(new_menu_id) 
-                    }).await?;
+                    dialogue
+                        .update(State::ChainSelected {
+                            chain: chain.clone(),
+                            message_id: Some(new_menu_id),
+                        })
+                        .await?;
                 }
                 _ => {
                     bot.send_message(
@@ -1380,20 +1838,22 @@ pub async fn handle_text(
             }
             return Ok(());
         }
-        
+
         // Check if it's a chain name
         let chains = cache.list_chains().await?;
         if chains.iter().any(|c| c.to_lowercase() == text_lower) {
             // Delete any previous menu if in chain selected state
             let state = dialogue.get().await?.unwrap_or_default();
-            if let State::ChainSelected { message_id, .. } = state {
-                if let Some(menu_id) = message_id {
-                    if let Err(e) = bot.delete_message(msg.chat.id, menu_id).await {
-                        eprintln!("Failed to delete previous menu: {}", e);
-                    }
+            if let State::ChainSelected {
+                message_id: Some(menu_id),
+                ..
+            } = state
+            {
+                if let Err(e) = bot.delete_message(msg.chat.id, menu_id).await {
+                    eprintln!("Failed to delete previous menu: {}", e);
                 }
             }
-            
+
             // Show chain menu inline
             let mut buttons = vec![
                 vec![
@@ -1414,26 +1874,45 @@ pub async fn handle_text(
                     InlineKeyboardButton::callback("5. IBC-ID", "action:ibc_id"),
                     InlineKeyboardButton::callback("6. IBC Route Info", "action:ibc_route"),
                 ]);
-                buttons.push(vec![
-                    InlineKeyboardButton::callback("7. Check Balance", "action:check_balance"),
-                ]);
+                buttons.push(vec![InlineKeyboardButton::callback(
+                    "7. Check Balance",
+                    "action:check_balance",
+                )]);
+                if is_osmosis_mainnet(&text_lower) {
+                    push_osmosis_buttons(&mut buttons);
+                }
             }
 
             // Add installation guide link if available on Polkachu
             if let Some(install_url) = get_polkachu_installation_url(&text_lower) {
-                buttons.push(vec![InlineKeyboardButton::url("Node Installation Guide", install_url.parse().unwrap())]);
+                buttons.push(vec![InlineKeyboardButton::url(
+                    "Node Installation Guide",
+                    install_url.parse().unwrap(),
+                )]);
             }
 
-            buttons.push(vec![InlineKeyboardButton::callback("← Back", "back:chains")]);
-            
+            buttons.push(vec![InlineKeyboardButton::callback(
+                "← Back",
+                "back:chains",
+            )]);
+
             let keyboard = InlineKeyboardMarkup::new(buttons);
-            
-            let sent_msg = bot.send_message(msg.chat.id, format!("Selected: {}\n\nChoose an action:", text_lower))
+
+            let sent_msg = bot
+                .send_message(
+                    msg.chat.id,
+                    format!("Selected: {}\n\nChoose an action:", text_lower),
+                )
                 .reply_markup(keyboard)
                 .await?;
-            
+
             // Update dialogue with the new menu's message ID
-            dialogue.update(State::ChainSelected { chain: text_lower.clone(), message_id: Some(sent_msg.id) }).await?;
+            dialogue
+                .update(State::ChainSelected {
+                    chain: text_lower.clone(),
+                    message_id: Some(sent_msg.id),
+                })
+                .await?;
         } else {
             bot.send_message(
                 msg.chat.id,
@@ -1442,7 +1921,7 @@ pub async fn handle_text(
             .await?;
         }
     }
-    
+
     Ok(())
 }
 
@@ -1455,7 +1934,7 @@ pub async fn handle_callback(
     // This is a fallback handler for callbacks that don't match expected states
     // Reset the dialogue and prompt user to start over
     dialogue.reset().await?;
-    
+
     if let Some(Message { chat, .. }) = &q.message {
         bot.send_message(
             chat.id,
@@ -1463,7 +1942,7 @@ pub async fn handle_callback(
         )
         .await?;
     }
-    
+
     bot.answer_callback_query(q.id).await?;
     Ok(())
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4,7 +4,8 @@ use crate::{
     utils::{escape_markdown, find_healthy_endpoint, find_healthy_rest_endpoint,
             query_ibc_denom, query_ibc_denom_with_fallback, query_ibc_channel_info_with_fallback,
             extract_channel_from_path, format_channel_input, query_abci_info,
-            get_polkachu_installation_url, PAGE_SIZE},
+            get_polkachu_installation_url, query_balances_with_fallback, format_amount,
+            truncate_ibc_hash, PAGE_SIZE},
 };
 use std::sync::Arc;
 use teloxide::{
@@ -311,11 +312,14 @@ async fn show_chain_menu(
         ],
     ];
 
-    // Add IBC options for mainnets
+    // Add IBC options and balance check for mainnets
     if !chain.contains("testnet") {
         buttons.push(vec![
             InlineKeyboardButton::callback("5. IBC-ID", "action:ibc_id"),
             InlineKeyboardButton::callback("6. IBC Route Info", "action:ibc_route"),
+        ]);
+        buttons.push(vec![
+            InlineKeyboardButton::callback("7. Check Balance", "action:check_balance"),
         ]);
     }
 
@@ -325,9 +329,9 @@ async fn show_chain_menu(
     }
 
     buttons.push(vec![InlineKeyboardButton::callback("← Back", "back:chains")]);
-    
+
     let keyboard = InlineKeyboardMarkup::new(buttons);
-    
+
     // Send as a new message instead of editing
     if let Some(Message { chat, .. }) = &q.message {
         let sent_msg = bot.send_message(chat.id, format!("Selected: {}\n\nChoose an action:", chain))
@@ -378,11 +382,14 @@ async fn send_chain_menu(
         ],
     ];
 
-    // Add IBC options for mainnets
+    // Add IBC options and balance check for mainnets
     if !chain.contains("testnet") {
         buttons.push(vec![
             InlineKeyboardButton::callback("5. IBC-ID", "action:ibc_id"),
             InlineKeyboardButton::callback("6. IBC Route Info", "action:ibc_route"),
+        ]);
+        buttons.push(vec![
+            InlineKeyboardButton::callback("7. Check Balance", "action:check_balance"),
         ]);
     }
 
@@ -394,14 +401,14 @@ async fn send_chain_menu(
     buttons.push(vec![InlineKeyboardButton::callback("← Back", "back:chains")]);
 
     let keyboard = InlineKeyboardMarkup::new(buttons);
-    
+
     let sent_msg = bot.send_message(
         msg.chat.id,
         format!("Selected: {}\n\nChoose an action:", chain),
     )
     .reply_markup(keyboard)
     .await?;
-    
+
     Ok(sent_msg.id)
 }
 
@@ -488,6 +495,16 @@ pub async fn handle_chain_action(
                     let msg_id = q.message.as_ref().map(|m| m.id);
                     dialogue.update(State::AwaitingIbcChannel { chain, message_id: msg_id }).await?;
                     bot.send_message(chat.id, "Enter IBC channel (e.g., 0 or channel-0):\nOptionally add port (e.g., channel-0 transfer):")
+                        .await?;
+                }
+            }
+            "action:check_balance" => {
+                // Delete the menu with effect
+                if let Some(Message { id, chat, .. }) = &q.message {
+                    delete_message_with_effect(&bot, chat.id, *id).await?;
+                    let msg_id = q.message.as_ref().map(|m| m.id);
+                    dialogue.update(State::AwaitingWalletAddress { chain, message_id: msg_id }).await?;
+                    bot.send_message(chat.id, "Enter wallet address to check balance:")
                         .await?;
                 }
             }
@@ -901,6 +918,116 @@ pub async fn handle_ibc_channel(
     Ok(())
 }
 
+pub async fn handle_wallet_address(
+    bot: Bot,
+    dialogue: MyDialogue,
+    cache: Arc<RegistryCache>,
+    msg: Message,
+    (chain, _message_id): (String, Option<MessageId>),
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(text) = msg.text() {
+        let address = text.trim();
+
+        // Basic validation
+        if address.is_empty() || address.len() < 10 || address.len() > 100 {
+            bot.send_message(msg.chat.id, "Please enter a valid wallet address.").await?;
+            let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
+            dialogue.update(State::ChainSelected {
+                chain: chain.clone(),
+                message_id: Some(new_menu_id)
+            }).await?;
+            return Ok(());
+        }
+
+        // Get chain info to find REST endpoints
+        if let Some(chain_info) = cache.get_chain(&chain).await? {
+            match query_balances_with_fallback(&chain_info.apis.rest, address, None).await {
+                Ok((balances, next_key)) => {
+                    if balances.is_empty() {
+                        let message = format!(
+                            "No balances found for address:\n`{}`\n\n\
+                            The address might be empty or invalid for {}\\.",
+                            escape_markdown(address),
+                            escape_markdown(&chain)
+                        );
+                        bot.send_message(msg.chat.id, message)
+                            .parse_mode(ParseMode::MarkdownV2)
+                            .await?;
+                    } else {
+                        // Build balance list with IBC denom resolution
+                        let mut balance_lines = Vec::new();
+                        for bal in &balances {
+                            let display_denom = if bal.denom.starts_with("ibc/") {
+                                // Try to resolve IBC denom
+                                let ibc_hash = bal.denom.strip_prefix("ibc/").unwrap_or(&bal.denom);
+                                match query_ibc_denom_with_fallback(&chain_info.apis.rest, ibc_hash).await {
+                                    Ok((_path, base_denom)) => {
+                                        format!("{} \\({}\\)", escape_markdown(&base_denom), escape_markdown(&truncate_ibc_hash(&bal.denom)))
+                                    }
+                                    Err(_) => escape_markdown(&bal.denom),
+                                }
+                            } else {
+                                escape_markdown(&bal.denom)
+                            };
+
+                            balance_lines.push(format!(
+                                "{} {}",
+                                escape_markdown(&format_amount(&bal.amount)),
+                                display_denom
+                            ));
+                        }
+
+                        let truncated_addr = if address.len() > 20 {
+                            format!("{}\\.\\.\\.", escape_markdown(&address[..20]))
+                        } else {
+                            escape_markdown(address)
+                        };
+
+                        let mut message = format!(
+                            "💰 *Balances for* `{}`:\n\n{}",
+                            truncated_addr,
+                            balance_lines.join("\n")
+                        );
+
+                        if next_key.is_some() {
+                            message.push_str("\n\n_Showing first 100 tokens \\(more available\\)_");
+                        }
+
+                        bot.send_message(msg.chat.id, message)
+                            .parse_mode(ParseMode::MarkdownV2)
+                            .await?;
+                    }
+                }
+                Err(e) => {
+                    let error_message = format!(
+                        "❌ Could not fetch balances:\n{}\n\n\
+                        The address might be invalid or the chain's REST API might be unavailable\\.",
+                        escape_markdown(&e.to_string())
+                    );
+                    bot.send_message(msg.chat.id, error_message)
+                        .parse_mode(ParseMode::MarkdownV2)
+                        .await?;
+                }
+            }
+        } else {
+            bot.send_message(msg.chat.id, "Chain not found").await?;
+        }
+
+        // Show the menu after showing balance info
+        let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
+        dialogue.update(State::ChainSelected {
+            chain: chain.clone(),
+            message_id: Some(new_menu_id)
+        }).await?;
+    } else {
+        dialogue.update(State::ChainSelected {
+            chain,
+            message_id: None
+        }).await?;
+    }
+    Ok(())
+}
+
 pub async fn handle_text(
     bot: Bot,
     dialogue: MyDialogue,
@@ -909,7 +1036,7 @@ pub async fn handle_text(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(text) = msg.text() {
         let text_lower = text.to_lowercase();
-        
+
         // Handle numeric menu selection
         if let Ok(num) = text.parse::<usize>() {
             let state = dialogue.get().await?.unwrap_or_default();
@@ -923,6 +1050,7 @@ pub async fn handle_text(
                             "explorers",
                             "ibc_id",
                             "ibc_route",
+                            "check_balance",
                         ]
                     } else {
                         vec![
@@ -1174,6 +1302,10 @@ pub async fn handle_text(
                                 dialogue.update(State::AwaitingIbcChannel { chain, message_id: Some(msg.id) }).await?;
                                 bot.send_message(msg.chat.id, "Enter IBC channel (e.g., 0 or channel-0):\nOptionally add port (e.g., channel-0 transfer):").await?;
                             }
+                            "check_balance" => {
+                                dialogue.update(State::AwaitingWalletAddress { chain, message_id: Some(msg.id) }).await?;
+                                bot.send_message(msg.chat.id, "Enter wallet address to check balance:").await?;
+                            }
                             _ => {}
                         }
                     } else {
@@ -1274,13 +1406,16 @@ pub async fn handle_text(
                 ],
             ];
 
-            // Add IBC options for mainnets
+            // Add IBC options and balance check for mainnets
             // Check if it's a testnet by seeing if it's in the testnets list
             let testnets = cache.list_testnets().await.unwrap_or_default();
             if !testnets.iter().any(|t| t.to_lowercase() == text_lower) {
                 buttons.push(vec![
                     InlineKeyboardButton::callback("5. IBC-ID", "action:ibc_id"),
                     InlineKeyboardButton::callback("6. IBC Route Info", "action:ibc_route"),
+                ]);
+                buttons.push(vec![
+                    InlineKeyboardButton::callback("7. Check Balance", "action:check_balance"),
                 ]);
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ mod bot;
 mod cache;
 mod commands;
 mod handlers;
-mod utils;
 mod tests;
+mod utils;
 
 use anyhow::Result;
 use dotenv::dotenv;
@@ -17,12 +17,14 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     let bot_token = env::var("BOT_TOKEN").expect("BOT_TOKEN must be set");
-    
+
     info!("Starting CosmoClerk Rust bot...");
-    
+
     let bot = Bot::new(bot_token);
-    
-    bot::run(bot).await.map_err(|e| anyhow::anyhow!("Bot error: {}", e))?;
-    
+
+    bot::run(bot)
+        .await
+        .map_err(|e| anyhow::anyhow!("Bot error: {}", e))?;
+
     Ok(())
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,98 +1,18 @@
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use crate::{
         bot::{MyDialogue, State},
-        cache::RegistryCache,
-    };
-    use std::sync::Arc;
-    use teloxide::{
-        dispatching::dialogue::InMemStorage,
-        prelude::*,
-        types::{
-            CallbackQuery, Chat, ChatId, ChatKind, InlineKeyboardButton, 
-            Message, MessageId, MessageKind, User, UserId,
+        utils::{
+            format_channel_input, format_osmosis_pool_incentives, format_osmosis_pool_info,
+            format_osmosis_token_price, Balance, OsmosisGaugeIncentive, OsmosisPoolIncentives,
+            OsmosisTokenPrice,
         },
     };
-
-    // Helper function to create a test bot
-    fn create_test_bot() -> Bot {
-        Bot::new("TEST_TOKEN")
-    }
-
-    // Helper function to create a test user
-    fn create_test_user() -> User {
-        User {
-            id: UserId(123456),
-            is_bot: false,
-            first_name: "Test".to_string(),
-            last_name: Some("User".to_string()),
-            username: Some("testuser".to_string()),
-            language_code: Some("en".to_string()),
-            is_premium: false,
-            added_to_attachment_menu: false,
-        }
-    }
-
-    // Helper function to create a test chat
-    fn create_test_chat() -> Chat {
-        Chat {
-            id: ChatId(123456),
-            kind: ChatKind::Private(teloxide::types::ChatPrivate {
-                username: Some("testuser".to_string()),
-                first_name: Some("Test".to_string()),
-                last_name: Some("User".to_string()),
-                bio: None,
-                has_private_forwards: None,
-                has_restricted_voice_and_video_messages: None,
-                emoji_status_custom_emoji_id: None,
-            }),
-            photo: None,
-            pinned_message: None,
-            message_auto_delete_time: None,
-            has_hidden_members: false,
-            has_aggressive_anti_spam_enabled: false,
-        }
-    }
-
-    // Helper function to create a test message
-    fn create_test_message(text: Option<String>) -> Message {
-        Message {
-            id: MessageId(1),
-            thread_id: None,
-            date: chrono::Utc::now(),
-            chat: create_test_chat(),
-            via_bot: None,
-            kind: MessageKind::Common(teloxide::types::MessageCommon {
-                from: Some(create_test_user()),
-                sender_chat: None,
-                author_signature: None,
-                forward: None,
-                reply_to_message: None,
-                edit_date: None,
-                media_kind: teloxide::types::MediaKind::Text(teloxide::types::MediaText {
-                    text: text.unwrap_or_else(|| "/start".to_string()),
-                    entities: vec![],
-                }),
-                reply_markup: None,
-                is_topic_message: false,
-                is_automatic_forward: false,
-                has_protected_content: false,
-            }),
-        }
-    }
-
-    // Helper function to create a test callback query
-    fn create_test_callback_query(data: String, message: Option<Message>) -> CallbackQuery {
-        CallbackQuery {
-            id: "test_callback_123".to_string(),
-            from: create_test_user(),
-            message,
-            inline_message_id: None,
-            chat_instance: "test_instance".to_string(),
-            data: Some(data),
-            game_short_name: None,
-        }
-    }
+    use serde_json::json;
+    use teloxide::{
+        dispatching::dialogue::InMemStorage,
+        types::{ChatId, InlineKeyboardButton, MessageId},
+    };
 
     // Helper function to create a test dialogue
     async fn create_test_dialogue() -> MyDialogue {
@@ -103,40 +23,60 @@ mod tests {
     #[tokio::test]
     async fn test_state_transitions() {
         let dialogue = create_test_dialogue().await;
-        
+
         // Test initial state
         let state = dialogue.get().await.unwrap();
         assert!(state.is_none() || matches!(state, Some(State::Start)));
-        
+
         // Test transition to SelectingChain
-        dialogue.update(State::SelectingChain {
-            page: 0,
-            is_testnet: false,
-            message_id: None,
-            last_selected_chain: None,
-        }).await.unwrap();
-        
+        dialogue
+            .update(State::SelectingChain {
+                page: 0,
+                is_testnet: false,
+                message_id: None,
+                last_selected_chain: None,
+            })
+            .await
+            .unwrap();
+
         let state = dialogue.get().await.unwrap().unwrap();
         assert!(matches!(state, State::SelectingChain { .. }));
-        
+
         // Test transition to ChainSelected
-        dialogue.update(State::ChainSelected {
-            chain: "osmosis".to_string(),
-            message_id: None,
-        }).await.unwrap();
-        
+        dialogue
+            .update(State::ChainSelected {
+                chain: "osmosis".to_string(),
+                message_id: None,
+            })
+            .await
+            .unwrap();
+
         let state = dialogue.get().await.unwrap().unwrap();
         assert!(matches!(state, State::ChainSelected { .. }));
-        
+
         // Test transition to AwaitingIbcDenom
-        dialogue.update(State::AwaitingIbcDenom {
-            chain: "osmosis".to_string(),
-            message_id: None,
-        }).await.unwrap();
-        
+        dialogue
+            .update(State::AwaitingIbcDenom {
+                chain: "osmosis".to_string(),
+                message_id: None,
+            })
+            .await
+            .unwrap();
+
         let state = dialogue.get().await.unwrap().unwrap();
         assert!(matches!(state, State::AwaitingIbcDenom { .. }));
-        
+
+        dialogue
+            .update(State::AwaitingOsmosisPoolInfo {
+                chain: "osmosis".to_string(),
+                message_id: None,
+            })
+            .await
+            .unwrap();
+
+        let state = dialogue.get().await.unwrap().unwrap();
+        assert!(matches!(state, State::AwaitingOsmosisPoolInfo { .. }));
+
         // Test reset
         dialogue.reset().await.unwrap();
         let state = dialogue.get().await.unwrap();
@@ -148,21 +88,30 @@ mod tests {
         // Test select chain callback
         let select_data = "select:osmosis";
         assert_eq!(select_data.strip_prefix("select:"), Some("osmosis"));
-        
+
         // Test page navigation callback
         let page_data = "page:2";
         assert_eq!(page_data.strip_prefix("page:"), Some("2"));
-        assert_eq!(page_data.strip_prefix("page:").unwrap().parse::<usize>(), Ok(2));
-        
+        assert_eq!(
+            page_data.strip_prefix("page:").unwrap().parse::<usize>(),
+            Ok(2)
+        );
+
         // Test toggle testnet callback
         let toggle_data = "toggle_testnet:true";
         assert_eq!(toggle_data.strip_prefix("toggle_testnet:"), Some("true"));
-        assert_eq!(toggle_data.strip_prefix("toggle_testnet:").unwrap().parse::<bool>(), Ok(true));
-        
+        assert_eq!(
+            toggle_data
+                .strip_prefix("toggle_testnet:")
+                .unwrap()
+                .parse::<bool>(),
+            Ok(true)
+        );
+
         // Test action callbacks
         let action_data = "action:chain_info";
         assert_eq!(action_data, "action:chain_info");
-        
+
         // Test back navigation
         let back_data = "back:chains";
         assert_eq!(back_data, "back:chains");
@@ -170,40 +119,43 @@ mod tests {
 
     #[tokio::test]
     async fn test_numeric_menu_selection() {
-        let actions = vec![
+        let actions = [
             "chain_info",
             "peer_nodes",
             "endpoints",
             "explorers",
             "ibc_id",
         ];
-        
+
         // Test valid selections
         for num in 1..=5 {
             assert!(num > 0 && num <= actions.len());
-            assert_eq!(actions[num - 1], match num {
-                1 => "chain_info",
-                2 => "peer_nodes",
-                3 => "endpoints",
-                4 => "explorers",
-                5 => "ibc_id",
-                _ => panic!("Unexpected number"),
-            });
+            assert_eq!(
+                actions[num - 1],
+                match num {
+                    1 => "chain_info",
+                    2 => "peer_nodes",
+                    3 => "endpoints",
+                    4 => "explorers",
+                    5 => "ibc_id",
+                    _ => panic!("Unexpected number"),
+                }
+            );
         }
-        
+
         // Test invalid selections
-        assert!(!(0 > 0 && 0 <= actions.len()));
-        assert!(!(6 > 0 && 6 <= actions.len()));
+        assert!(actions.get(0_usize.wrapping_sub(1)).is_none());
+        assert!(actions.get(5).is_none());
     }
 
     #[tokio::test]
     async fn test_ibc_denom_validation() {
         let valid_ibc = "ibc/ABC123DEF456";
         let invalid_ibc = "not_an_ibc_denom";
-        
+
         assert!(valid_ibc.starts_with("ibc/"));
         assert!(!invalid_ibc.starts_with("ibc/"));
-        
+
         if let Some(hash) = valid_ibc.strip_prefix("ibc/") {
             assert_eq!(hash, "ABC123DEF456");
         }
@@ -211,24 +163,30 @@ mod tests {
 
     #[tokio::test]
     async fn test_chain_name_matching() {
-        let chains = vec![
+        let chains = [
             "osmosis".to_string(),
             "cosmoshub".to_string(),
             "juno".to_string(),
             "osmosistestnet".to_string(),
         ];
-        
+
         // Test exact matches (case insensitive)
         let input = "osmosis";
-        assert!(chains.iter().any(|c| c.to_lowercase() == input.to_lowercase()));
-        
+        assert!(chains
+            .iter()
+            .any(|c| c.to_lowercase() == input.to_lowercase()));
+
         let input = "COSMOSHUB";
-        assert!(chains.iter().any(|c| c.to_lowercase() == input.to_lowercase()));
-        
+        assert!(chains
+            .iter()
+            .any(|c| c.to_lowercase() == input.to_lowercase()));
+
         // Test non-matches
         let input = "invalid_chain";
-        assert!(!chains.iter().any(|c| c.to_lowercase() == input.to_lowercase()));
-        
+        assert!(!chains
+            .iter()
+            .any(|c| c.to_lowercase() == input.to_lowercase()));
+
         // Test testnet filtering
         let testnets: Vec<String> = chains
             .iter()
@@ -237,7 +195,7 @@ mod tests {
             .collect();
         assert_eq!(testnets.len(), 1);
         assert_eq!(testnets[0], "osmosistestnet");
-        
+
         let mainnets: Vec<String> = chains
             .iter()
             .filter(|c| !c.contains("testnet"))
@@ -248,17 +206,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyboard_button_creation() {
-        let chains = vec!["osmosis", "juno", "axelar", "stride", "noble"];
+        let chains = ["osmosis", "juno", "axelar", "stride", "noble"];
         let page = 0;
         let page_size = 3;
-        
+
         let start = page * page_size;
         let end = (start + page_size).min(chains.len());
         let page_chains = &chains[start..end];
-        
+
         assert_eq!(page_chains.len(), 3);
         assert_eq!(page_chains, &["osmosis", "juno", "axelar"]);
-        
+
         // Test button creation
         let mut buttons = vec![];
         for chunk in page_chains.chunks(3) {
@@ -270,22 +228,28 @@ mod tests {
                 .collect();
             buttons.push(row);
         }
-        
+
         assert_eq!(buttons.len(), 1);
         assert_eq!(buttons[0].len(), 3);
-        
+
         // Test navigation buttons
-        let total_pages = (chains.len() + page_size - 1) / page_size;
+        let total_pages = chains.len().div_ceil(page_size);
         assert_eq!(total_pages, 2);
-        
+
         let mut nav_buttons = vec![];
         if page > 0 {
-            nav_buttons.push(InlineKeyboardButton::callback("← Previous", format!("page:{}", page - 1)));
+            nav_buttons.push(InlineKeyboardButton::callback(
+                "← Previous",
+                format!("page:{}", page - 1),
+            ));
         }
         if page < total_pages - 1 {
-            nav_buttons.push(InlineKeyboardButton::callback("Next →", format!("page:{}", page + 1)));
+            nav_buttons.push(InlineKeyboardButton::callback(
+                "Next →",
+                format!("page:{}", page + 1),
+            ));
         }
-        
+
         assert_eq!(nav_buttons.len(), 1); // Only "Next" button for page 0
     }
 
@@ -298,31 +262,37 @@ mod tests {
             message_id: Some(MessageId(123)),
             last_selected_chain: Some("osmosis".to_string()),
         };
-        
-        if let State::SelectingChain { page, is_testnet, message_id, last_selected_chain } = state {
+
+        if let State::SelectingChain {
+            page,
+            is_testnet,
+            message_id,
+            last_selected_chain,
+        } = state
+        {
             assert_eq!(page, 1);
-            assert_eq!(is_testnet, false);
+            assert!(!is_testnet);
             assert_eq!(message_id, Some(MessageId(123)));
             assert_eq!(last_selected_chain, Some("osmosis".to_string()));
         }
-        
+
         // Test ChainSelected state extraction
         let state = State::ChainSelected {
             chain: "cosmoshub".to_string(),
             message_id: Some(MessageId(456)),
         };
-        
+
         if let State::ChainSelected { chain, message_id } = state {
             assert_eq!(chain, "cosmoshub");
             assert_eq!(message_id, Some(MessageId(456)));
         }
-        
+
         // Test AwaitingIbcDenom state extraction
         let state = State::AwaitingIbcDenom {
             chain: "juno".to_string(),
             message_id: None,
         };
-        
+
         if let State::AwaitingIbcDenom { chain, message_id } = state {
             assert_eq!(chain, "juno");
             assert_eq!(message_id, None);
@@ -332,29 +302,82 @@ mod tests {
     #[tokio::test]
     async fn test_escape_markdown() {
         use crate::utils::escape_markdown;
-        
+
         let input = "Test_string*with[special]chars";
         let escaped = escape_markdown(input);
         assert_eq!(escaped, "Test\\_string\\*with\\[special\\]chars");
-        
+
         let input = "https://example.com/path?param=value";
         let escaped = escape_markdown(input);
         assert_eq!(escaped, "https://example\\.com/path?param\\=value");
     }
 
-    #[tokio::test]
-    async fn test_fallback_handler_parameters() {
-        // The fallback handler should now accept all required parameters
-        let _bot = create_test_bot();
-        let _dialogue = create_test_dialogue().await;
-        let _cache = Arc::new(RegistryCache::new(30));
-        let _query = create_test_callback_query("unknown_action".to_string(), None);
-        
-        // This test verifies that the handler signature is correct
-        // The actual handler call would be:
-        // handlers::handle_callback(bot, dialogue, cache, query).await
-        
-        // Verify the parameters match what dptree provides
-        assert!(true); // Compilation success means the signature is correct
+    #[test]
+    fn test_channel_input_formatting() {
+        assert_eq!(format_channel_input("0"), "channel-0");
+        assert_eq!(format_channel_input("channel-23"), "channel-23");
+        assert_eq!(format_channel_input("transfer"), "transfer");
+    }
+
+    #[test]
+    fn test_osmosis_pool_info_formatting() {
+        let pool = json!({
+            "@type": "/osmosis.gamm.v1beta1.Pool",
+            "address": "osmo1pool",
+            "pool_params": {"swap_fee": "0.002000000000000000"},
+            "total_shares": {"amount": "1234567890"},
+            "pool_assets": [
+                {"token": {"denom": "uosmo", "amount": "1000000"}, "weight": "50"},
+                {"token": {"denom": "ibc/1234567890ABCDEF", "amount": "2000000"}, "weight": "50"}
+            ]
+        });
+
+        let formatted = format_osmosis_pool_info("1", &pool);
+
+        assert!(formatted.contains("Osmosis Pool 1"));
+        assert!(formatted.contains("Type: Pool"));
+        assert!(formatted.contains("uosmo: 1,000,000"));
+        assert!(formatted.contains("ibc/12345678..."));
+    }
+
+    #[test]
+    fn test_osmosis_pool_incentives_formatting() {
+        let incentives = OsmosisPoolIncentives {
+            gauges: vec![OsmosisGaugeIncentive {
+                gauge_id: "1".to_string(),
+                duration: "86400s".to_string(),
+                incentive_percentage: "0.100000000000000000".to_string(),
+                coins: vec![Balance {
+                    denom: "uosmo".to_string(),
+                    amount: "1000000".to_string(),
+                }],
+                distributed_coins: vec![],
+            }],
+            cl_records: vec![],
+        };
+
+        let formatted = format_osmosis_pool_incentives("1", &incentives);
+
+        assert!(formatted.contains("Gauge 1"));
+        assert!(formatted.contains("1,000,000 uosmo"));
+        assert!(formatted.contains("distributed: none"));
+    }
+
+    #[test]
+    fn test_osmosis_token_price_formatting() {
+        let price = OsmosisTokenPrice {
+            name: "Osmosis".to_string(),
+            symbol: "OSMO".to_string(),
+            denom: "uosmo".to_string(),
+            quote_symbol: "USDC".to_string(),
+            quote_denom: "ibc/498A0751C798A0D9".to_string(),
+            price: "0.037".to_string(),
+        };
+
+        let formatted = format_osmosis_token_price(&price);
+
+        assert!(formatted.contains("Token: Osmosis (OSMO)"));
+        assert!(formatted.contains("Price: 0.037 USDC"));
+        assert!(formatted.contains("ibc/498A0751..."));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
-use reqwest;
-use serde_json::Value;
-use serde::{Deserialize, Serialize};
 use cosmos_chain_registry::chain;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 
 pub const PAGE_SIZE: usize = 18;
@@ -15,30 +14,105 @@ pub fn get_polkachu_installation_url(chain_name: &str) -> Option<String> {
         ("elysnetwork", "elys"),
         ("elys", "elys"),
         ("hippo", "hippo"),
-    ].into_iter().collect();
+    ]
+    .into_iter()
+    .collect();
 
     // All supported chains on Polkachu (verified working)
     let supported: std::collections::HashSet<&str> = [
-        "axelar", "babylon", "celestia", "cosmos", "dydx", "initia",
-        "injective", "osmosis", "sei", "akash", "allora", "althea",
-        "andromeda", "archway", "arkeo", "atomone", "aura", "band",
-        "bitcanna", "bitsong", "bitway", "canto", "chain4energy", "cheqd",
-        "chihuahua", "comdex", "crescent", "cronos", "decentr", "dhealth",
-        "dymension", "elys", "evmos", "fetch", "functionx", "gitopia",
-        "gravity", "haqq", "hippo", "humans", "intento", "jackal", "juno",
-        "kava", "kichain", "kopi", "kujira", "kyve", "loyal", "lum",
-        "lumera", "mantra", "meme", "milkyway", "neutron", "nibiru",
-        "nillion", "noble", "nolus", "nym", "odin", "omniflix", "passage",
-        "persistence", "picasso", "planq", "provenance", "quicksilver",
-        "saga", "shentu", "shido", "sifchain", "sommelier", "source",
-        "stargaze", "stride", "sunrise", "symphony", "tacchain", "teritori",
-        "terra", "umee", "ununifi", "xpla",
-    ].into_iter().collect();
+        "axelar",
+        "babylon",
+        "celestia",
+        "cosmos",
+        "dydx",
+        "initia",
+        "injective",
+        "osmosis",
+        "sei",
+        "akash",
+        "allora",
+        "althea",
+        "andromeda",
+        "archway",
+        "arkeo",
+        "atomone",
+        "aura",
+        "band",
+        "bitcanna",
+        "bitsong",
+        "bitway",
+        "canto",
+        "chain4energy",
+        "cheqd",
+        "chihuahua",
+        "comdex",
+        "crescent",
+        "cronos",
+        "decentr",
+        "dhealth",
+        "dymension",
+        "elys",
+        "evmos",
+        "fetch",
+        "functionx",
+        "gitopia",
+        "gravity",
+        "haqq",
+        "hippo",
+        "humans",
+        "intento",
+        "jackal",
+        "juno",
+        "kava",
+        "kichain",
+        "kopi",
+        "kujira",
+        "kyve",
+        "loyal",
+        "lum",
+        "lumera",
+        "mantra",
+        "meme",
+        "milkyway",
+        "neutron",
+        "nibiru",
+        "nillion",
+        "noble",
+        "nolus",
+        "nym",
+        "odin",
+        "omniflix",
+        "passage",
+        "persistence",
+        "picasso",
+        "planq",
+        "provenance",
+        "quicksilver",
+        "saga",
+        "shentu",
+        "shido",
+        "sifchain",
+        "sommelier",
+        "source",
+        "stargaze",
+        "stride",
+        "sunrise",
+        "symphony",
+        "tacchain",
+        "teritori",
+        "terra",
+        "umee",
+        "ununifi",
+        "xpla",
+    ]
+    .into_iter()
+    .collect();
 
     let chain_lower = chain_name.to_lowercase();
 
     // Check for special mapping first
-    let slug = special_mappings.get(chain_lower.as_str())
+    let slug = special_mappings
+        .get(chain_lower.as_str())
         .map(|s| s.to_string())
         .unwrap_or_else(|| chain_lower.clone());
 
@@ -108,10 +182,7 @@ pub async fn check_endpoint_health(endpoint: &str, is_rpc: bool) -> bool {
     }
 }
 
-pub async fn find_healthy_endpoint(
-    endpoints: &[chain::Rpc],
-    is_rpc: bool,
-) -> Option<String> {
+pub async fn find_healthy_endpoint(endpoints: &[chain::Rpc], is_rpc: bool) -> Option<String> {
     for endpoint in endpoints {
         if check_endpoint_health(&endpoint.address, is_rpc).await {
             return Some(endpoint.address.clone());
@@ -120,9 +191,7 @@ pub async fn find_healthy_endpoint(
     None
 }
 
-pub async fn find_healthy_rest_endpoint(
-    endpoints: &[chain::Rest],
-) -> Option<String> {
+pub async fn find_healthy_rest_endpoint(endpoints: &[chain::Rest]) -> Option<String> {
     for endpoint in endpoints {
         if check_endpoint_health(&endpoint.address, false).await {
             return Some(endpoint.address.clone());
@@ -176,13 +245,15 @@ pub async fn query_ibc_denom(
         if let Some(denom) = json["denom"].as_object() {
             // The alternate format has "base" instead of "base_denom"
             // and "trace" array instead of "path"
-            let base_denom = denom.get("base")
+            let base_denom = denom
+                .get("base")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| anyhow::anyhow!("Missing base in alternate response"))?;
 
             // Reconstruct path from trace array
             let path = if let Some(trace) = denom.get("trace").and_then(|v| v.as_array()) {
-                trace.iter()
+                trace
+                    .iter()
                     .filter_map(|entry| {
                         let port = entry["port_id"].as_str()?;
                         let channel = entry["channel_id"].as_str()?;
@@ -197,7 +268,9 @@ pub async fn query_ibc_denom(
             return Ok((path, base_denom.to_string()));
         }
 
-        return Err(anyhow::anyhow!("Invalid response format from alternate endpoint"));
+        return Err(anyhow::anyhow!(
+            "Invalid response format from alternate endpoint"
+        ));
     }
 
     let json: Value = response.json().await?;
@@ -205,10 +278,9 @@ pub async fn query_ibc_denom(
 
     // Parse the standard response format
     if let Some(trace) = json["denom_trace"].as_object() {
-        let path = trace.get("path")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let base_denom = trace.get("base_denom")
+        let path = trace.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let base_denom = trace
+            .get("base_denom")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing base_denom in response"))?;
 
@@ -216,7 +288,9 @@ pub async fn query_ibc_denom(
     }
 
     // If denom_trace is not found in the expected format
-    Err(anyhow::anyhow!("Invalid response format: missing denom_trace"))
+    Err(anyhow::anyhow!(
+        "Invalid response format: missing denom_trace"
+    ))
 }
 
 pub async fn query_ibc_denom_with_fallback(
@@ -272,12 +346,19 @@ pub async fn query_ibc_channel_info(
         .to_string();
 
     // Fetch channel data
-    let channel_url = format!("{}/ibc/core/channel/v1/channels/{}/ports/{}", base_url, channel_id, port_id);
+    let channel_url = format!(
+        "{}/ibc/core/channel/v1/channels/{}/ports/{}",
+        base_url, channel_id, port_id
+    );
     log::info!("Fetching channel data from: {}", channel_url);
 
     let response = client.get(&channel_url).send().await?;
     if !response.status().is_success() {
-        return Err(anyhow::anyhow!("Channel {} not found on port {}", channel_id, port_id));
+        return Err(anyhow::anyhow!(
+            "Channel {} not found on port {}",
+            channel_id,
+            port_id
+        ));
     }
     let channel_data: Value = response.json().await?;
 
@@ -292,7 +373,10 @@ pub async fn query_ibc_channel_info(
         .to_string();
 
     // Fetch connection data
-    let connection_url = format!("{}/ibc/core/connection/v1/connections/{}", base_url, connection_id);
+    let connection_url = format!(
+        "{}/ibc/core/connection/v1/connections/{}",
+        base_url, connection_id
+    );
     log::info!("Fetching connection data from: {}", connection_url);
 
     let response = client.get(&connection_url).send().await?;
@@ -317,8 +401,10 @@ pub async fn query_ibc_channel_info(
         .to_string();
 
     // Fetch counterparty chain ID
-    let client_state_url = format!("{}/ibc/core/channel/v1/channels/{}/ports/{}/client_state",
-                                   base_url, channel_id, port_id);
+    let client_state_url = format!(
+        "{}/ibc/core/channel/v1/channels/{}/ports/{}/client_state",
+        base_url, channel_id, port_id
+    );
     log::info!("Fetching counterparty chain ID from: {}", client_state_url);
 
     let response = client.get(&client_state_url).send().await?;
@@ -358,7 +444,10 @@ pub async fn query_ibc_channel_info_with_fallback(
             continue;
         }
 
-        log::info!("Trying REST endpoint for channel info: {}", endpoint.address);
+        log::info!(
+            "Trying REST endpoint for channel info: {}",
+            endpoint.address
+        );
 
         match query_ibc_channel_info(&endpoint.address, channel_id, port_id).await {
             Ok(result) => return Ok(result),
@@ -369,7 +458,8 @@ pub async fn query_ibc_channel_info_with_fallback(
         }
     }
 
-    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available for channel query")))
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available for channel query")))
 }
 
 pub fn extract_channel_from_path(path: &str) -> Option<String> {
@@ -439,8 +529,14 @@ pub async fn query_abci_info(rpc_endpoint: &str) -> Option<AbciInfo> {
 
     Some(AbciInfo {
         version: resp["version"].as_str().unwrap_or("Unknown").to_string(),
-        last_block_height: resp["last_block_height"].as_str().unwrap_or("Unknown").to_string(),
-        last_block_app_hash: resp["last_block_app_hash"].as_str().unwrap_or("Unknown").to_string(),
+        last_block_height: resp["last_block_height"]
+            .as_str()
+            .unwrap_or("Unknown")
+            .to_string(),
+        last_block_app_hash: resp["last_block_app_hash"]
+            .as_str()
+            .unwrap_or("Unknown")
+            .to_string(),
     })
 }
 
@@ -449,6 +545,116 @@ pub async fn query_abci_info(rpc_endpoint: &str) -> Option<AbciInfo> {
 pub struct Balance {
     pub denom: String,
     pub amount: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct OsmosisGaugeIncentive {
+    pub gauge_id: String,
+    pub duration: String,
+    pub incentive_percentage: String,
+    pub coins: Vec<Balance>,
+    pub distributed_coins: Vec<Balance>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OsmosisClIncentive {
+    pub incentive_id: String,
+    pub denom: String,
+    pub remaining_amount: String,
+    pub emission_rate: String,
+    pub start_time: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct OsmosisPoolIncentives {
+    pub gauges: Vec<OsmosisGaugeIncentive>,
+    pub cl_records: Vec<OsmosisClIncentive>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OsmosisTokenPrice {
+    pub name: String,
+    pub symbol: String,
+    pub denom: String,
+    pub quote_symbol: String,
+    pub quote_denom: String,
+    pub price: String,
+}
+
+#[derive(Debug, Clone)]
+struct OsmosisTokenMetadata {
+    name: String,
+    symbol: String,
+    denom: String,
+    preview: bool,
+}
+
+async fn get_json(client: &reqwest::Client, url: &str) -> anyhow::Result<Value> {
+    let response = client.get(url).send().await?;
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "request failed with status {} for {}",
+            response.status(),
+            url
+        ));
+    }
+
+    Ok(response.json().await?)
+}
+
+fn parse_coin_array(value: &Value) -> Vec<Balance> {
+    value
+        .as_array()
+        .map(|coins| {
+            coins
+                .iter()
+                .filter_map(|coin| {
+                    Some(Balance {
+                        denom: coin["denom"].as_str()?.to_string(),
+                        amount: coin["amount"].as_str()?.to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn encode_query_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn resolve_token_metadata(metadata: &Value, input: &str) -> Option<OsmosisTokenMetadata> {
+    let needle = input.trim();
+    let mut preview_match = None;
+
+    for token in metadata.as_object()?.values() {
+        let denom = token["coinMinimalDenom"].as_str().unwrap_or_default();
+        let symbol = token["symbol"].as_str().unwrap_or_default();
+
+        if denom.eq_ignore_ascii_case(needle) || symbol.eq_ignore_ascii_case(needle) {
+            let candidate = OsmosisTokenMetadata {
+                name: token["name"].as_str().unwrap_or(symbol).to_string(),
+                symbol: symbol.to_string(),
+                denom: denom.to_string(),
+                preview: token["preview"].as_bool().unwrap_or(false),
+            };
+
+            if !candidate.preview {
+                return Some(candidate);
+            }
+            preview_match = Some(candidate);
+        }
+    }
+
+    preview_match
 }
 
 /// Query wallet balances from chain REST API
@@ -535,7 +741,8 @@ pub async fn query_balances_with_fallback(
         }
     }
 
-    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available for balance query")))
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available for balance query")))
 }
 
 /// Format amount with thousands separators
@@ -563,4 +770,278 @@ pub fn truncate_ibc_hash(hash: &str) -> String {
     } else {
         hash.to_string()
     }
+}
+
+pub async fn query_osmosis_pool_info(
+    endpoints: &[chain::Rest],
+    pool_id: &str,
+) -> anyhow::Result<Value> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+    let paths = [
+        format!("/osmosis/poolmanager/v1beta1/pools/{pool_id}"),
+        format!("/osmosis/gamm/v1beta1/pools/{pool_id}"),
+    ];
+    let max_attempts = 3.min(endpoints.len());
+    let mut last_error = None;
+
+    for endpoint in endpoints.iter().take(max_attempts) {
+        if endpoint.address.starts_with("http://") || endpoint.address.is_empty() {
+            continue;
+        }
+
+        for path in &paths {
+            let url = format!("{}{}", endpoint.address.trim_end_matches('/'), path);
+            match get_json(&client, &url).await {
+                Ok(json) => {
+                    if let Some(pool) = json.get("pool") {
+                        return Ok(pool.clone());
+                    }
+                    last_error = Some(anyhow::anyhow!("pool response missing pool object"));
+                }
+                Err(e) => last_error = Some(e),
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("No Osmosis REST pool endpoint available")))
+}
+
+pub async fn query_osmosis_pool_incentives(
+    endpoints: &[chain::Rest],
+    pool_id: &str,
+) -> anyhow::Result<OsmosisPoolIncentives> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+    let max_attempts = 3.min(endpoints.len());
+    let mut last_error = None;
+
+    for endpoint in endpoints.iter().take(max_attempts) {
+        if endpoint.address.starts_with("http://") || endpoint.address.is_empty() {
+            continue;
+        }
+
+        let base = endpoint.address.trim_end_matches('/');
+        let gauge_url = format!("{base}/osmosis/pool-incentives/v1beta1/gauge-ids/{pool_id}");
+        let gauge_ids = match get_json(&client, &gauge_url).await {
+            Ok(json) => json,
+            Err(e) => {
+                last_error = Some(e);
+                continue;
+            }
+        };
+
+        let mut gauges = Vec::new();
+        for gauge in gauge_ids["gauge_ids_with_duration"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .take(8)
+        {
+            let Some(gauge_id) = gauge["gauge_id"].as_str() else {
+                continue;
+            };
+            let detail_url = format!("{base}/osmosis/incentives/v1beta1/gauge_by_id/{gauge_id}");
+            let detail = get_json(&client, &detail_url).await.unwrap_or_default();
+            let gauge_detail = &detail["gauge"];
+
+            gauges.push(OsmosisGaugeIncentive {
+                gauge_id: gauge_id.to_string(),
+                duration: gauge["duration"].as_str().unwrap_or("unknown").to_string(),
+                incentive_percentage: gauge["gauge_incentive_percentage"]
+                    .as_str()
+                    .unwrap_or("unknown")
+                    .to_string(),
+                coins: parse_coin_array(&gauge_detail["coins"]),
+                distributed_coins: parse_coin_array(&gauge_detail["distributed_coins"]),
+            });
+        }
+
+        let cl_url = format!(
+            "{base}/osmosis/concentratedliquidity/v1beta1/incentive_records?pool_id={pool_id}"
+        );
+        let cl_json = get_json(&client, &cl_url).await.unwrap_or_default();
+        let cl_records = cl_json["incentive_records"]
+            .as_array()
+            .map(|records| {
+                records
+                    .iter()
+                    .take(8)
+                    .filter_map(|record| {
+                        let body = &record["incentive_record_body"];
+                        let coin = &body["remaining_coin"];
+                        Some(OsmosisClIncentive {
+                            incentive_id: record["incentive_id"].as_str()?.to_string(),
+                            denom: coin["denom"].as_str()?.to_string(),
+                            remaining_amount: coin["amount"].as_str()?.to_string(),
+                            emission_rate: body["emission_rate"].as_str()?.to_string(),
+                            start_time: body["start_time"]
+                                .as_str()
+                                .unwrap_or("unknown")
+                                .to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        return Ok(OsmosisPoolIncentives { gauges, cl_records });
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("No Osmosis incentive endpoint available")))
+}
+
+pub async fn query_osmosis_token_price(token: &str) -> anyhow::Result<OsmosisTokenPrice> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+    let metadata = get_json(&client, "https://sqs.osmosis.zone/tokens/metadata").await?;
+    let token_metadata = resolve_token_metadata(&metadata, token).unwrap_or_else(|| {
+        let trimmed = token.trim().to_string();
+        OsmosisTokenMetadata {
+            name: trimmed.clone(),
+            symbol: trimmed.clone(),
+            denom: trimmed,
+            preview: false,
+        }
+    });
+
+    let price_url = format!(
+        "https://sqs.osmosis.zone/tokens/prices?base={}",
+        encode_query_component(&token_metadata.denom)
+    );
+    let price_json = get_json(&client, &price_url).await?;
+    let quotes = price_json
+        .get(&token_metadata.denom)
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow::anyhow!("No price quote found for {}", token_metadata.symbol))?;
+    let (quote_denom, price) = quotes
+        .iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No price quote found for {}", token_metadata.symbol))?;
+    let quote_metadata = resolve_token_metadata(&metadata, quote_denom);
+
+    Ok(OsmosisTokenPrice {
+        name: token_metadata.name,
+        symbol: token_metadata.symbol,
+        denom: token_metadata.denom,
+        quote_symbol: quote_metadata
+            .as_ref()
+            .map(|m| m.symbol.clone())
+            .unwrap_or_else(|| truncate_ibc_hash(quote_denom)),
+        quote_denom: quote_denom.to_string(),
+        price: price.as_str().unwrap_or("unknown").to_string(),
+    })
+}
+
+fn short_pool_type(pool_type: &str) -> &str {
+    pool_type.rsplit('.').next().unwrap_or(pool_type)
+}
+
+pub fn format_osmosis_pool_info(pool_id: &str, pool: &Value) -> String {
+    let pool_type = pool["@type"].as_str().unwrap_or("unknown");
+    let mut message = format!(
+        "Osmosis Pool {pool_id}\nType: {}\n",
+        short_pool_type(pool_type)
+    );
+
+    if let Some(address) = pool["address"].as_str() {
+        message.push_str(&format!("Address: {address}\n"));
+    }
+    if let Some(swap_fee) = pool["pool_params"]["swap_fee"].as_str() {
+        message.push_str(&format!("Swap Fee: {swap_fee}\n"));
+    }
+    if let Some(total_shares) = pool["total_shares"]["amount"].as_str() {
+        message.push_str(&format!("Total Shares: {}\n", format_amount(total_shares)));
+    }
+
+    if let Some(assets) = pool["pool_assets"].as_array() {
+        message.push_str("\nAssets:\n");
+        for asset in assets.iter().take(8) {
+            let token = &asset["token"];
+            let denom = token["denom"].as_str().unwrap_or("unknown");
+            let amount = token["amount"].as_str().unwrap_or("0");
+            let weight = asset["weight"].as_str().unwrap_or("unknown");
+            message.push_str(&format!(
+                "- {}: {} (weight {})\n",
+                truncate_ibc_hash(denom),
+                format_amount(amount),
+                weight
+            ));
+        }
+    } else if let Some(liquidity) = pool["current_tick_liquidity"].as_str() {
+        message.push_str(&format!("Current Tick Liquidity: {liquidity}\n"));
+    }
+
+    message
+}
+
+fn format_coin_lines(coins: &[Balance]) -> String {
+    if coins.is_empty() {
+        return "none".to_string();
+    }
+
+    coins
+        .iter()
+        .map(|coin| {
+            format!(
+                "{} {}",
+                format_amount(&coin.amount),
+                truncate_ibc_hash(&coin.denom)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+pub fn format_osmosis_pool_incentives(pool_id: &str, incentives: &OsmosisPoolIncentives) -> String {
+    if incentives.gauges.is_empty() && incentives.cl_records.is_empty() {
+        return format!("No active incentives found for Osmosis pool {pool_id}.");
+    }
+
+    let mut message = format!("Osmosis Pool {pool_id} Incentives\n");
+
+    if !incentives.gauges.is_empty() {
+        message.push_str("\nGauge Incentives:\n");
+        for gauge in &incentives.gauges {
+            message.push_str(&format!(
+                "- Gauge {} ({}): {}\n  remaining: {}\n  distributed: {}\n",
+                gauge.gauge_id,
+                gauge.duration,
+                gauge.incentive_percentage,
+                format_coin_lines(&gauge.coins),
+                format_coin_lines(&gauge.distributed_coins)
+            ));
+        }
+    }
+
+    if !incentives.cl_records.is_empty() {
+        message.push_str("\nConcentrated Liquidity Records:\n");
+        for record in &incentives.cl_records {
+            message.push_str(&format!(
+                "- Incentive {}: {} {} remaining, emission {}, starts {}\n",
+                record.incentive_id,
+                format_amount(&record.remaining_amount),
+                truncate_ibc_hash(&record.denom),
+                record.emission_rate,
+                record.start_time
+            ));
+        }
+    }
+
+    message
+}
+
+pub fn format_osmosis_token_price(price: &OsmosisTokenPrice) -> String {
+    format!(
+        "Osmosis Price\nToken: {} ({})\nDenom: {}\nPrice: {} {}\nQuote Denom: {}",
+        price.name,
+        price.symbol,
+        truncate_ibc_hash(&price.denom),
+        price.price,
+        price.quote_symbol,
+        truncate_ibc_hash(&price.quote_denom)
+    )
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -443,3 +443,124 @@ pub async fn query_abci_info(rpc_endpoint: &str) -> Option<AbciInfo> {
         last_block_app_hash: resp["last_block_app_hash"].as_str().unwrap_or("Unknown").to_string(),
     })
 }
+
+/// Balance entry from bank query
+#[derive(Debug, Clone)]
+pub struct Balance {
+    pub denom: String,
+    pub amount: String,
+}
+
+/// Query wallet balances from chain REST API
+/// Returns balances and optional pagination key for next page
+pub async fn query_balances(
+    rest_endpoint: &str,
+    address: &str,
+    pagination_key: Option<&str>,
+) -> anyhow::Result<(Vec<Balance>, Option<String>)> {
+    let base_url = rest_endpoint.trim_end_matches('/');
+
+    let url = match pagination_key {
+        Some(key) => format!(
+            "{}/cosmos/bank/v1beta1/balances/{}?pagination.limit=100&pagination.key={}",
+            base_url, address, key
+        ),
+        None => format!(
+            "{}/cosmos/bank/v1beta1/balances/{}?pagination.limit=100",
+            base_url, address
+        ),
+    };
+
+    log::info!("Querying balances at: {}", url);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+
+    let response = client.get(&url).send().await?;
+
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "Balance query failed with status: {}",
+            response.status()
+        ));
+    }
+
+    let json: Value = response.json().await?;
+    log::debug!("Balance response: {}", json);
+
+    let balances = json["balances"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Invalid response: missing balances array"))?
+        .iter()
+        .filter_map(|b| {
+            let denom = b["denom"].as_str()?.to_string();
+            let amount = b["amount"].as_str()?.to_string();
+            Some(Balance { denom, amount })
+        })
+        .collect();
+
+    // Check for pagination
+    let next_key = json["pagination"]["next_key"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    Ok((balances, next_key))
+}
+
+/// Query balances with fallback to multiple REST endpoints
+pub async fn query_balances_with_fallback(
+    endpoints: &[chain::Rest],
+    address: &str,
+    pagination_key: Option<&str>,
+) -> anyhow::Result<(Vec<Balance>, Option<String>)> {
+    let mut last_error = None;
+    let max_attempts = 3.min(endpoints.len());
+
+    for endpoint in endpoints.iter().take(max_attempts) {
+        // Skip non-HTTPS endpoints
+        if endpoint.address.starts_with("http://") || endpoint.address.is_empty() {
+            continue;
+        }
+
+        log::info!("Trying REST endpoint for balances: {}", endpoint.address);
+
+        match query_balances(&endpoint.address, address, pagination_key).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                log::warn!("Failed with endpoint {}: {}", endpoint.address, e);
+                last_error = Some(e);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available for balance query")))
+}
+
+/// Format amount with thousands separators
+pub fn format_amount(amount: &str) -> String {
+    // Parse the amount string as a number and format with commas
+    if let Ok(num) = amount.parse::<u128>() {
+        let s = num.to_string();
+        let mut result = String::new();
+        for (i, c) in s.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                result.insert(0, ',');
+            }
+            result.insert(0, c);
+        }
+        result
+    } else {
+        amount.to_string()
+    }
+}
+
+/// Truncate IBC hash for display (e.g., "ibc/27A6..." showing first 8 chars after ibc/)
+pub fn truncate_ibc_hash(hash: &str) -> String {
+    if hash.len() > 12 {
+        format!("{}...", &hash[..12])
+    } else {
+        hash.to_string()
+    }
+}


### PR DESCRIPTION
## Summary
- Add the Rust wallet balance lookup flow for mainnet chains.
- Restore Osmosis-only pool info, LP incentive, and token price actions in the Rust bot.
- Add deterministic formatter/state tests and a root contributor guide.
- Remove tracked Node package metadata from the Rust branch while retaining legacy JS/TS on archive branches.

## Validation
- cargo fmt -- --check
- cargo check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo build --release
- git diff --check

## Notes
- No GitHub Actions checks are configured/reported for this branch.
- Deployment uses the Rust release binary and existing BOT_TOKEN environment.