### PR TITLE
[codex] add grpc-first wallet queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-CosmoClerk is a Rust 2021 Telegram bot for Cosmos chain-registry lookups. Source lives in `src/`: `main.rs` loads `.env` and starts the bot, `bot.rs` owns the Teloxide dialogue state machine, `handlers.rs` contains message/callback flows, `cache.rs` wraps chain data with a 30-minute TTL, `utils.rs` holds HTTP/IBC/Osmosis helpers, and `commands.rs` defines slash commands. Tests currently live in `src/tests.rs`. `README_RUST.md` documents setup, and `cosmoclerk.service` is the systemd deployment example. Legacy JS/TS code belongs only on isolated archive branches; keep Node package artifacts out of the Rust branch.
+CosmoClerk is a Rust 2021 Telegram bot for Cosmos chain-registry lookups. Source lives in `src/`: `main.rs` loads `.env` and starts the bot, `bot.rs` owns the Teloxide dialogue state machine, `handlers.rs` contains message/callback flows, `cache.rs` wraps chain data with a 30-minute TTL, `utils.rs` holds gRPC/HTTP/IBC/Osmosis helpers, and `commands.rs` defines slash commands. Tests currently live in `src/tests.rs`. `README_RUST.md` documents setup, and `cosmoclerk.service` is the systemd deployment example. Legacy JS/TS code belongs only on isolated archive branches; keep Node package artifacts out of the Rust branch.
 
 ## Build, Test, and Development Commands
 - `cp .env.example .env` then set `BOT_TOKEN` before running locally.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,14 @@ teloxide = { version = "0.12", features = ["macros"] }
 # Chain registry from crates.io
 cosmos-chain-registry = "0.5.0"
 
+# Cosmos SDK and IBC gRPC clients
+cosmos-sdk-proto = { version = "0.27", features = ["grpc-transport"] }
+ibc-proto = "0.52"
+tonic = { version = "0.13", features = ["transport", "tls-native-roots"] }
+prost = "0.13"
+tendermint-proto = "0.40"
+base64 = "0.22"
+
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 

--- a/README_RUST.md
+++ b/README_RUST.md
@@ -18,9 +18,9 @@ Core bot features:
 -  Peer nodes listing
 -  Endpoints display (RPC, REST, GRPC, EVM RPC where available)
 -  Block explorers
--  IBC denomination lookup
--  IBC route lookup by channel
--  Wallet balance lookup with IBC denom resolution
+-  gRPC-first IBC denomination lookup with REST fallback
+-  gRPC-first IBC route lookup by channel with REST fallback
+-  gRPC-first wallet balance lookup with IBC denom resolution
 -  Polkachu node installation guide links for supported chains
 -  Osmosis-specific features:
   - Pool info
@@ -64,8 +64,12 @@ RUST_LOG=debug cargo run
 - `src/bot.rs` - Bot state machine and dialogue handling
 - `src/handlers.rs` - Message and callback handlers
 - `src/cache.rs` - Registry data caching layer
-- `src/utils.rs` - Helper functions
+- `src/utils.rs` - gRPC, REST, IBC, Osmosis, and formatting helpers
 - `src/commands.rs` - Bot command definitions
+
+Direct Cosmos SDK queries prefer chain-registry gRPC endpoints, with Polkachu
+endpoints tried first when present. REST/RPC is retained as fallback for chains
+or modules where gRPC is unavailable.
 
 Legacy JavaScript/TypeScript versions are archived on isolated branches. The active `main` line is the Rust rewrite and should stay free of Node package artifacts.
 

--- a/cosmoclerk.service
+++ b/cosmoclerk.service
@@ -32,7 +32,7 @@ NoNewPrivileges=true
 #ReadWritePaths=/var/log/cosmoclerk
 
 # Resource limits
-MemoryLimit=256M
+MemoryMax=256M
 CPUQuota=50%
 
 # Logging

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -15,7 +15,7 @@ use cosmos_chain_registry::AssetList;
 use std::sync::Arc;
 use teloxide::{
     prelude::*,
-    types::{ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MessageId, ParseMode},
+    types::{ChatAction, ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MessageId, ParseMode},
 };
 
 pub async fn start(
@@ -423,6 +423,12 @@ async fn edit_or_send_markdown_result(
     }
 
     Ok(())
+}
+
+async fn send_processing_action(bot: &Bot, chat_id: ChatId) {
+    if let Err(e) = bot.send_chat_action(chat_id, ChatAction::Typing).await {
+        log::debug!("Could not send Telegram processing action: {}", e);
+    }
 }
 
 fn is_osmosis_mainnet(chain: &str) -> bool {
@@ -1027,6 +1033,7 @@ pub async fn handle_ibc_denom(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(text) = msg.text() {
         if let Some(ibc_hash) = text.strip_prefix("ibc/") {
+            send_processing_action(&bot, msg.chat.id).await;
             let status = bot
                 .send_message(msg.chat.id, format!("Resolving IBC denom on {chain}..."))
                 .await?;
@@ -1065,7 +1072,7 @@ pub async fn handle_ibc_denom(
                                 {
                                     Ok(info) => {
                                         message.push_str(&format!(
-                                            "\n\n📍 **Source Chain:** {}\n(via {})",
+                                            "\n\n📍 Source Chain: {}\nvia {}",
                                             info.counterparty_chain_id, channel
                                         ));
                                     }
@@ -1160,6 +1167,7 @@ pub async fn handle_ibc_channel(
             return Ok(());
         }
 
+        send_processing_action(&bot, msg.chat.id).await;
         let status = bot
             .send_message(msg.chat.id, format!("Looking up IBC route on {chain}..."))
             .await?;
@@ -1176,14 +1184,14 @@ pub async fn handle_ibc_channel(
                 Ok(info) => {
                     let message = format!(
                         "✅ IBC Route Information\n\n\
-                        **Source Chain:** {}\n\
-                        **Destination Chain:** {}\n\n\
-                        **Channel Details:**\n\
+                        Source Chain: {}\n\
+                        Destination Chain: {}\n\n\
+                        Channel Details:\n\
                         • Channel: {}\n\
                         • Port: {}\n\
                         • Client ID: {}\n\
                         • Connection: {}\n\n\
-                        **Counterparty Details:**\n\
+                        Counterparty Details:\n\
                         • Channel: {}\n\
                         • Client ID: {}\n\
                         • Connection: {}",
@@ -1277,6 +1285,7 @@ pub async fn handle_wallet_address(
             return Ok(());
         }
 
+        send_processing_action(&bot, msg.chat.id).await;
         let status = bot
             .send_message(msg.chat.id, format!("Checking balances on {chain}..."))
             .await?;
@@ -2008,6 +2017,7 @@ pub async fn handle_text(
                 State::ChainSelected { chain, .. } | State::AwaitingIbcDenom { chain, .. } => {
                     let ibc_hash = &text[4..]; // Remove "ibc/" prefix
 
+                    send_processing_action(&bot, msg.chat.id).await;
                     let status = bot
                         .send_message(msg.chat.id, format!("Resolving IBC denom on {chain}..."))
                         .await?;
@@ -2045,7 +2055,7 @@ pub async fn handle_text(
                                         {
                                             Ok(info) => {
                                                 message.push_str(&format!(
-                                                    "\n\n📍 **Source Chain:** {}\n(via {})",
+                                                    "\n\n📍 Source Chain: {}\nvia {}",
                                                     info.counterparty_chain_id, channel
                                                 ));
                                             }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3,18 +3,19 @@ use crate::{
     cache::RegistryCache,
     utils::{
         escape_markdown, extract_channel_from_path, find_healthy_endpoint,
-        find_healthy_rest_endpoint, format_amount, format_channel_input,
+        find_healthy_grpc_endpoint, find_healthy_rest_endpoint, format_channel_input,
         format_osmosis_pool_incentives, format_osmosis_pool_info, format_osmosis_token_price,
-        get_polkachu_installation_url, query_abci_info, query_balances_with_fallback,
-        query_ibc_channel_info_with_fallback, query_ibc_denom, query_ibc_denom_with_fallback,
-        query_osmosis_pool_incentives, query_osmosis_pool_info, query_osmosis_token_price,
-        truncate_ibc_hash, PAGE_SIZE,
+        format_wallet_balances, get_polkachu_installation_url, query_abci_info,
+        query_abci_info_grpc, query_balances_grpc_first, query_ibc_channel_info_grpc_first,
+        query_ibc_denom_grpc_first, query_osmosis_pool_incentives, query_osmosis_pool_info,
+        query_osmosis_token_price, WalletBalance, PAGE_SIZE,
     },
 };
+use cosmos_chain_registry::AssetList;
 use std::sync::Arc;
 use teloxide::{
     prelude::*,
-    types::{InlineKeyboardButton, InlineKeyboardMarkup, MessageId, ParseMode},
+    types::{ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MessageId, ParseMode},
 };
 
 pub async fn start(
@@ -341,6 +342,86 @@ async fn edit_callback_message_with_markup(
             .reply_markup(keyboard)
             .await?;
     }
+    Ok(())
+}
+
+async fn edit_status_message(
+    bot: &Bot,
+    chat_id: ChatId,
+    message_id: MessageId,
+    text: String,
+    parse_mode: Option<ParseMode>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(parse_mode) = parse_mode {
+        bot.edit_message_text(chat_id, message_id, text)
+            .parse_mode(parse_mode)
+            .await?;
+    } else {
+        bot.edit_message_text(chat_id, message_id, text).await?;
+    }
+
+    Ok(())
+}
+
+fn split_telegram_message(text: &str, max_len: usize) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+
+    for block in text.split("\n\n") {
+        let separator_len = if current.is_empty() { 0 } else { 2 };
+        if !current.is_empty() && current.len() + separator_len + block.len() > max_len {
+            chunks.push(current);
+            current = block.to_string();
+        } else {
+            if !current.is_empty() {
+                current.push_str("\n\n");
+            }
+            current.push_str(block);
+        }
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+
+    chunks
+}
+
+async fn edit_or_send_markdown_result(
+    bot: &Bot,
+    chat_id: ChatId,
+    status_id: MessageId,
+    message: String,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let chunks = split_telegram_message(&message, 3800);
+
+    if chunks.len() == 1 {
+        edit_status_message(
+            bot,
+            chat_id,
+            status_id,
+            message,
+            Some(ParseMode::MarkdownV2),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    edit_status_message(
+        bot,
+        chat_id,
+        status_id,
+        format!("Found a large response; sending {} parts...", chunks.len()),
+        None,
+    )
+    .await?;
+
+    for chunk in chunks {
+        bot.send_message(chat_id, chunk)
+            .parse_mode(ParseMode::MarkdownV2)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -722,14 +803,20 @@ async fn show_chain_info(
             .await
             .unwrap_or_else(|| "Unknown".to_string());
 
+        let grpc = find_healthy_grpc_endpoint(&chain_info.apis.grpc)
+            .await
+            .unwrap_or_else(|| "Unknown".to_string());
+
         let explorer = chain_info
             .explorers
             .first()
             .map(|e| e.url.as_str())
             .unwrap_or("Unknown");
 
-        // Query ABCI info for version and block data
-        let abci_info = if rpc != "Unknown" {
+        // Prefer gRPC for node status, then fall back to RPC ABCI.
+        let abci_info = if grpc != "Unknown" {
+            query_abci_info_grpc(&grpc).await
+        } else if rpc != "Unknown" {
             query_abci_info(&rpc).await
         } else {
             None
@@ -741,6 +828,7 @@ async fn show_chain_info(
             Chain Name: `{}`\n\
             RPC: `{}`\n\
             REST: `{}`\n\
+            GRPC: `{}`\n\
             Address Prefix: `{}`\n\
             Base Denom: `{}`\n\
             Cointype: `{}`\n\
@@ -751,6 +839,7 @@ async fn show_chain_info(
             escape_markdown(&chain_info.chain_name),
             escape_markdown(&rpc),
             escape_markdown(&rest),
+            escape_markdown(&grpc),
             escape_markdown(&chain_info.bech32_prefix),
             escape_markdown(base_denom),
             chain_info.slip44,
@@ -938,26 +1027,36 @@ pub async fn handle_ibc_denom(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(text) = msg.text() {
         if let Some(ibc_hash) = text.strip_prefix("ibc/") {
-            // Get chain info to find REST endpoint
+            let status = bot
+                .send_message(msg.chat.id, format!("Resolving IBC denom on {chain}..."))
+                .await?;
+
             if let Some(chain_info) = cache.get_chain(&chain).await? {
-                match query_ibc_denom_with_fallback(&chain_info.apis.rest, ibc_hash).await {
-                    Ok((path, base_denom)) => {
-                        let mut message = if !path.is_empty() {
+                match query_ibc_denom_grpc_first(
+                    &chain_info.apis.grpc,
+                    &chain_info.apis.rest,
+                    ibc_hash,
+                )
+                .await
+                {
+                    Ok(trace) => {
+                        let mut message = if !trace.path.is_empty() {
                             format!(
                                 "✅ IBC Denom Trace Found:\n\nPath: {}\nBase Denomination: {}",
-                                path, base_denom
+                                trace.path, trace.base_denom
                             )
                         } else {
                             format!(
                                 "✅ IBC Denom Trace Found:\n\nBase Denomination: {}",
-                                base_denom
+                                trace.base_denom
                             )
                         };
 
                         // Try to extract channel from path and fetch route info
-                        if !path.is_empty() {
-                            if let Some(channel) = extract_channel_from_path(&path) {
-                                match query_ibc_channel_info_with_fallback(
+                        if !trace.path.is_empty() {
+                            if let Some(channel) = extract_channel_from_path(&trace.path) {
+                                match query_ibc_channel_info_grpc_first(
+                                    &chain_info.apis.grpc,
                                     &chain_info.apis.rest,
                                     &channel,
                                     "transfer",
@@ -981,18 +1080,26 @@ pub async fn handle_ibc_denom(
                             }
                         }
 
-                        bot.send_message(msg.chat.id, message).await?;
+                        edit_status_message(&bot, msg.chat.id, status.id, message, None).await?;
                     }
                     Err(e) => {
                         let error_message = format!(
-                            "❌ Could not resolve IBC denom:\n{}\n\nThis denom might not exist on {} or the chain's REST API might be unavailable.",
+                            "❌ Could not resolve IBC denom:\n{}\n\nThis denom might not exist on {} or the chain's APIs might be unavailable.",
                             e, chain
                         );
-                        bot.send_message(msg.chat.id, error_message).await?;
+                        edit_status_message(&bot, msg.chat.id, status.id, error_message, None)
+                            .await?;
                     }
                 }
             } else {
-                bot.send_message(msg.chat.id, "Chain not found").await?;
+                edit_status_message(
+                    &bot,
+                    msg.chat.id,
+                    status.id,
+                    "Chain not found".to_string(),
+                    None,
+                )
+                .await?;
             }
         } else {
             bot.send_message(
@@ -1053,10 +1160,18 @@ pub async fn handle_ibc_channel(
             return Ok(());
         }
 
-        // Get chain info to find REST endpoints
+        let status = bot
+            .send_message(msg.chat.id, format!("Looking up IBC route on {chain}..."))
+            .await?;
+
         if let Some(chain_info) = cache.get_chain(&chain).await? {
-            match query_ibc_channel_info_with_fallback(&chain_info.apis.rest, &channel_id, port_id)
-                .await
+            match query_ibc_channel_info_grpc_first(
+                &chain_info.apis.grpc,
+                &chain_info.apis.rest,
+                &channel_id,
+                port_id,
+            )
+            .await
             {
                 Ok(info) => {
                     let message = format!(
@@ -1082,7 +1197,7 @@ pub async fn handle_ibc_channel(
                         info.counterparty_client_id,
                         info.counterparty_connection_id
                     );
-                    bot.send_message(msg.chat.id, message).await?;
+                    edit_status_message(&bot, msg.chat.id, status.id, message, None).await?;
                 }
                 Err(e) => {
                     let error_message = format!(
@@ -1090,11 +1205,18 @@ pub async fn handle_ibc_channel(
                         Make sure the channel exists on {}.",
                         e, chain
                     );
-                    bot.send_message(msg.chat.id, error_message).await?;
+                    edit_status_message(&bot, msg.chat.id, status.id, error_message, None).await?;
                 }
             }
         } else {
-            bot.send_message(msg.chat.id, "Chain not found").await?;
+            edit_status_message(
+                &bot,
+                msg.chat.id,
+                status.id,
+                "Chain not found".to_string(),
+                None,
+            )
+            .await?;
         }
 
         // Show the menu after showing IBC route info
@@ -1114,6 +1236,21 @@ pub async fn handle_ibc_channel(
             .await?;
     }
     Ok(())
+}
+
+fn asset_label_for_denom(assets: Option<&AssetList>, denom: &str) -> Option<String> {
+    let asset = assets?.assets.iter().find(|asset| {
+        asset.base == denom
+            || asset
+                .denom_units
+                .iter()
+                .any(|denom_unit| denom_unit.denom == denom)
+    })?;
+
+    [&asset.symbol, &asset.name, &asset.display]
+        .into_iter()
+        .find(|label| !label.is_empty())
+        .cloned()
 }
 
 pub async fn handle_wallet_address(
@@ -1140,9 +1277,27 @@ pub async fn handle_wallet_address(
             return Ok(());
         }
 
-        // Get chain info to find REST endpoints
+        let status = bot
+            .send_message(msg.chat.id, format!("Checking balances on {chain}..."))
+            .await?;
+
         if let Some(chain_info) = cache.get_chain(&chain).await? {
-            match query_balances_with_fallback(&chain_info.apis.rest, address, None).await {
+            let assets_data = match cache.get_assets(&chain).await {
+                Ok(assets) => assets,
+                Err(e) => {
+                    log::warn!("Could not fetch asset metadata for {}: {}", chain, e);
+                    None
+                }
+            };
+
+            match query_balances_grpc_first(
+                &chain_info.apis.grpc,
+                &chain_info.apis.rest,
+                address,
+                None,
+            )
+            .await
+            {
                 Ok((balances, next_key)) => {
                     if balances.is_empty() {
                         let message = format!(
@@ -1151,73 +1306,70 @@ pub async fn handle_wallet_address(
                             escape_markdown(address),
                             escape_markdown(&chain)
                         );
-                        bot.send_message(msg.chat.id, message)
-                            .parse_mode(ParseMode::MarkdownV2)
-                            .await?;
+                        edit_or_send_markdown_result(&bot, msg.chat.id, status.id, message).await?;
                     } else {
-                        // Build balance list with IBC denom resolution
-                        let mut balance_lines = Vec::new();
-                        for bal in &balances {
-                            let display_denom = if bal.denom.starts_with("ibc/") {
-                                // Try to resolve IBC denom
-                                let ibc_hash = bal.denom.strip_prefix("ibc/").unwrap_or(&bal.denom);
-                                match query_ibc_denom_with_fallback(&chain_info.apis.rest, ibc_hash)
+                        let mut wallet_balances = Vec::with_capacity(balances.len());
+                        for balance in balances {
+                            let ibc_trace =
+                                if let Some(ibc_hash) = balance.denom.strip_prefix("ibc/") {
+                                    match query_ibc_denom_grpc_first(
+                                        &chain_info.apis.grpc,
+                                        &chain_info.apis.rest,
+                                        ibc_hash,
+                                    )
                                     .await
-                                {
-                                    Ok((_path, base_denom)) => {
-                                        format!(
-                                            "{} \\({}\\)",
-                                            escape_markdown(&base_denom),
-                                            escape_markdown(&truncate_ibc_hash(&bal.denom))
-                                        )
+                                    {
+                                        Ok(trace) => Some(trace),
+                                        Err(e) => {
+                                            log::warn!(
+                                                "Could not resolve IBC denom {}: {}",
+                                                balance.denom,
+                                                e
+                                            );
+                                            None
+                                        }
                                     }
-                                    Err(_) => escape_markdown(&bal.denom),
-                                }
-                            } else {
-                                escape_markdown(&bal.denom)
-                            };
+                                } else {
+                                    None
+                                };
+                            let asset_label =
+                                asset_label_for_denom(assets_data.as_ref(), &balance.denom);
 
-                            balance_lines.push(format!(
-                                "{} {}",
-                                escape_markdown(&format_amount(&bal.amount)),
-                                display_denom
-                            ));
+                            wallet_balances.push(WalletBalance {
+                                balance,
+                                ibc_trace,
+                                asset_label,
+                            });
                         }
 
-                        let truncated_addr = if address.len() > 20 {
-                            format!("{}\\.\\.\\.", escape_markdown(&address[..20]))
-                        } else {
-                            escape_markdown(address)
-                        };
-
-                        let mut message = format!(
-                            "💰 *Balances for* `{}`:\n\n{}",
-                            truncated_addr,
-                            balance_lines.join("\n")
+                        let message = format_wallet_balances(
+                            address,
+                            &chain,
+                            &wallet_balances,
+                            next_key.is_some(),
                         );
-
-                        if next_key.is_some() {
-                            message.push_str("\n\n_Showing first 100 tokens \\(more available\\)_");
-                        }
-
-                        bot.send_message(msg.chat.id, message)
-                            .parse_mode(ParseMode::MarkdownV2)
-                            .await?;
+                        edit_or_send_markdown_result(&bot, msg.chat.id, status.id, message).await?;
                     }
                 }
                 Err(e) => {
                     let error_message = format!(
                         "❌ Could not fetch balances:\n{}\n\n\
-                        The address might be invalid or the chain's REST API might be unavailable\\.",
+                        The address might be invalid or the chain's APIs might be unavailable\\.",
                         escape_markdown(&e.to_string())
                     );
-                    bot.send_message(msg.chat.id, error_message)
-                        .parse_mode(ParseMode::MarkdownV2)
+                    edit_or_send_markdown_result(&bot, msg.chat.id, status.id, error_message)
                         .await?;
                 }
             }
         } else {
-            bot.send_message(msg.chat.id, "Chain not found").await?;
+            edit_status_message(
+                &bot,
+                msg.chat.id,
+                status.id,
+                "Chain not found".to_string(),
+                None,
+            )
+            .await?;
         }
 
         // Show the menu after showing balance info
@@ -1269,26 +1421,45 @@ pub async fn handle_osmosis_pool_incentives(
             return Ok(());
         };
 
+        let status = bot
+            .send_message(
+                msg.chat.id,
+                format!("Fetching Osmosis pool {pool_id} incentives..."),
+            )
+            .await?;
+
         if let Some(chain_info) = cache.get_chain(&chain).await? {
             match query_osmosis_pool_incentives(&chain_info.apis.rest, &pool_id).await {
                 Ok(incentives) => {
-                    bot.send_message(
+                    edit_status_message(
+                        &bot,
                         msg.chat.id,
+                        status.id,
                         format_osmosis_pool_incentives(&pool_id, &incentives),
+                        None,
                     )
                     .await?;
                 }
                 Err(e) => {
-                    bot.send_message(
+                    edit_status_message(
+                        &bot,
                         msg.chat.id,
+                        status.id,
                         format!("Could not fetch Osmosis pool incentives: {e}"),
+                        None,
                     )
                     .await?;
                 }
             }
         } else {
-            bot.send_message(msg.chat.id, "Osmosis chain info not found.")
-                .await?;
+            edit_status_message(
+                &bot,
+                msg.chat.id,
+                status.id,
+                "Osmosis chain info not found.".to_string(),
+                None,
+            )
+            .await?;
         }
 
         let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
@@ -1323,20 +1494,45 @@ pub async fn handle_osmosis_pool_info(
             return Ok(());
         };
 
+        let status = bot
+            .send_message(
+                msg.chat.id,
+                format!("Fetching Osmosis pool {pool_id} info..."),
+            )
+            .await?;
+
         if let Some(chain_info) = cache.get_chain(&chain).await? {
             match query_osmosis_pool_info(&chain_info.apis.rest, &pool_id).await {
                 Ok(pool) => {
-                    bot.send_message(msg.chat.id, format_osmosis_pool_info(&pool_id, &pool))
-                        .await?;
+                    edit_status_message(
+                        &bot,
+                        msg.chat.id,
+                        status.id,
+                        format_osmosis_pool_info(&pool_id, &pool),
+                        None,
+                    )
+                    .await?;
                 }
                 Err(e) => {
-                    bot.send_message(msg.chat.id, format!("Could not fetch Osmosis pool: {e}"))
-                        .await?;
+                    edit_status_message(
+                        &bot,
+                        msg.chat.id,
+                        status.id,
+                        format!("Could not fetch Osmosis pool: {e}"),
+                        None,
+                    )
+                    .await?;
                 }
             }
         } else {
-            bot.send_message(msg.chat.id, "Osmosis chain info not found.")
-                .await?;
+            edit_status_message(
+                &bot,
+                msg.chat.id,
+                status.id,
+                "Osmosis chain info not found.".to_string(),
+                None,
+            )
+            .await?;
         }
 
         let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;
@@ -1365,14 +1561,33 @@ pub async fn handle_osmosis_token_price(
             )
             .await?;
         } else {
+            let status = bot
+                .send_message(
+                    msg.chat.id,
+                    format!("Fetching Osmosis price for {token}..."),
+                )
+                .await?;
+
             match query_osmosis_token_price(token).await {
                 Ok(price) => {
-                    bot.send_message(msg.chat.id, format_osmosis_token_price(&price))
-                        .await?;
+                    edit_status_message(
+                        &bot,
+                        msg.chat.id,
+                        status.id,
+                        format_osmosis_token_price(&price),
+                        None,
+                    )
+                    .await?;
                 }
                 Err(e) => {
-                    bot.send_message(msg.chat.id, format!("Could not fetch Osmosis price: {e}"))
-                        .await?;
+                    edit_status_message(
+                        &bot,
+                        msg.chat.id,
+                        status.id,
+                        format!("Could not fetch Osmosis price: {e}"),
+                        None,
+                    )
+                    .await?;
                 }
             }
         }
@@ -1459,14 +1674,20 @@ pub async fn handle_text(
                                         .await
                                         .unwrap_or_else(|| "Unknown".to_string());
 
+                                    let grpc = find_healthy_grpc_endpoint(&chain_info.apis.grpc)
+                                        .await
+                                        .unwrap_or_else(|| "Unknown".to_string());
+
                                     let explorer = chain_info
                                         .explorers
                                         .first()
                                         .map(|e| e.url.as_str())
                                         .unwrap_or("Unknown");
 
-                                    // Query ABCI info for version and block data
-                                    let abci_info = if rpc != "Unknown" {
+                                    // Prefer gRPC for node status, then fall back to RPC ABCI.
+                                    let abci_info = if grpc != "Unknown" {
+                                        query_abci_info_grpc(&grpc).await
+                                    } else if rpc != "Unknown" {
                                         query_abci_info(&rpc).await
                                     } else {
                                         None
@@ -1478,6 +1699,7 @@ pub async fn handle_text(
                                         Chain Name: `{}`\n\
                                         RPC: `{}`\n\
                                         REST: `{}`\n\
+                                        GRPC: `{}`\n\
                                         Address Prefix: `{}`\n\
                                         Base Denom: `{}`\n\
                                         Cointype: `{}`\n\
@@ -1488,6 +1710,7 @@ pub async fn handle_text(
                                         escape_markdown(&chain_info.chain_name),
                                         escape_markdown(&rpc),
                                         escape_markdown(&rest),
+                                        escape_markdown(&grpc),
                                         escape_markdown(&chain_info.bech32_prefix),
                                         escape_markdown(base_denom),
                                         chain_info.slip44,
@@ -1785,39 +2008,85 @@ pub async fn handle_text(
                 State::ChainSelected { chain, .. } | State::AwaitingIbcDenom { chain, .. } => {
                     let ibc_hash = &text[4..]; // Remove "ibc/" prefix
 
-                    // Get chain info to find REST endpoint
+                    let status = bot
+                        .send_message(msg.chat.id, format!("Resolving IBC denom on {chain}..."))
+                        .await?;
+
                     if let Some(chain_info) = cache.get_chain(&chain).await? {
-                        if let Some(rest) = find_healthy_rest_endpoint(&chain_info.apis.rest).await
+                        match query_ibc_denom_grpc_first(
+                            &chain_info.apis.grpc,
+                            &chain_info.apis.rest,
+                            ibc_hash,
+                        )
+                        .await
                         {
-                            match query_ibc_denom(&rest, ibc_hash).await {
-                                Ok((path, base_denom)) => {
-                                    let message = if !path.is_empty() {
-                                        format!("✅ IBC Denom Trace Found:\n\nPath: {}\nBase Denomination: {}", path, base_denom)
-                                    } else {
-                                        format!(
-                                            "✅ IBC Denom Trace Found:\n\nBase Denomination: {}",
-                                            base_denom
+                            Ok(trace) => {
+                                let mut message = if !trace.path.is_empty() {
+                                    format!(
+                                        "✅ IBC Denom Trace Found:\n\nPath: {}\nBase Denomination: {}",
+                                        trace.path, trace.base_denom
+                                    )
+                                } else {
+                                    format!(
+                                        "✅ IBC Denom Trace Found:\n\nBase Denomination: {}",
+                                        trace.base_denom
+                                    )
+                                };
+
+                                if !trace.path.is_empty() {
+                                    if let Some(channel) = extract_channel_from_path(&trace.path) {
+                                        match query_ibc_channel_info_grpc_first(
+                                            &chain_info.apis.grpc,
+                                            &chain_info.apis.rest,
+                                            &channel,
+                                            "transfer",
                                         )
-                                    };
-                                    bot.send_message(msg.chat.id, message).await?;
+                                        .await
+                                        {
+                                            Ok(info) => {
+                                                message.push_str(&format!(
+                                                    "\n\n📍 **Source Chain:** {}\n(via {})",
+                                                    info.counterparty_chain_id, channel
+                                                ));
+                                            }
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "Could not fetch channel info for {}: {}",
+                                                    channel,
+                                                    e
+                                                );
+                                            }
+                                        }
+                                    }
                                 }
-                                Err(e) => {
-                                    let error_message = format!(
-                                        "❌ Could not resolve IBC denom:\n{}\n\nThis denom might not exist on {} or the chain's REST API might be unavailable.",
-                                        e, chain
-                                    );
-                                    bot.send_message(msg.chat.id, error_message).await?;
-                                }
+
+                                edit_status_message(&bot, msg.chat.id, status.id, message, None)
+                                    .await?;
                             }
-                        } else {
-                            bot.send_message(
-                                msg.chat.id,
-                                "No healthy REST endpoint found for this chain",
-                            )
-                            .await?;
+                            Err(e) => {
+                                let error_message = format!(
+                                    "❌ Could not resolve IBC denom:\n{}\n\nThis denom might not exist on {} or the chain's APIs might be unavailable.",
+                                    e, chain
+                                );
+                                edit_status_message(
+                                    &bot,
+                                    msg.chat.id,
+                                    status.id,
+                                    error_message,
+                                    None,
+                                )
+                                .await?;
+                            }
                         }
                     } else {
-                        bot.send_message(msg.chat.id, "Chain not found").await?;
+                        edit_status_message(
+                            &bot,
+                            msg.chat.id,
+                            status.id,
+                            "Chain not found".to_string(),
+                            None,
+                        )
+                        .await?;
                     }
                     // Show menu again after IBC lookup
                     let new_menu_id = send_chain_menu(&bot, &msg, &chain).await?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -384,11 +384,11 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_prioritize_grpc_endpoints_prefers_polkachu_https() {
+    fn test_prioritize_grpc_endpoints_prefers_polkachu_plaintext() {
         let endpoints = vec![
             chain::Grpc {
                 address: "http://insecure.example:9090".to_string(),
-                provider: Some("Insecure".to_string()),
+                provider: Some("Explicit".to_string()),
             },
             chain::Grpc {
                 address: "community-grpc.example:443".to_string(),
@@ -405,7 +405,8 @@ mod unit_tests {
         assert_eq!(
             prioritized,
             vec![
-                "https://osmosis-grpc.polkachu.com:12590/".to_string(),
+                "http://osmosis-grpc.polkachu.com:12590/".to_string(),
+                "http://insecure.example:9090/".to_string(),
                 "https://community-grpc.example:443/".to_string()
             ]
         );
@@ -451,6 +452,7 @@ mod unit_tests {
         assert!(formatted.contains("Amount: `999,999`"));
         assert!(formatted
             .contains("Denom: `factory/osmo1n6asrjy9754q8y9jsxqf557zmsv3s3xa5m9eg5/uspice`"));
+        assert_eq!(formatted.matches("\\-\\-\\-").count(), 1);
         assert!(formatted.contains("_Showing first 100 assets; more balances are available\\._"));
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,10 +4,12 @@ mod unit_tests {
         bot::{MyDialogue, State},
         utils::{
             format_channel_input, format_osmosis_pool_incentives, format_osmosis_pool_info,
-            format_osmosis_token_price, Balance, OsmosisGaugeIncentive, OsmosisPoolIncentives,
-            OsmosisTokenPrice,
+            format_osmosis_token_price, format_wallet_balances, prioritize_grpc_endpoints, Balance,
+            IbcDenomTrace, OsmosisGaugeIncentive, OsmosisPoolIncentives, OsmosisTokenPrice,
+            WalletBalance,
         },
     };
+    use cosmos_chain_registry::chain;
     use serde_json::json;
     use teloxide::{
         dispatching::dialogue::InMemStorage,
@@ -379,5 +381,76 @@ mod unit_tests {
         assert!(formatted.contains("Token: Osmosis (OSMO)"));
         assert!(formatted.contains("Price: 0.037 USDC"));
         assert!(formatted.contains("ibc/498A0751..."));
+    }
+
+    #[test]
+    fn test_prioritize_grpc_endpoints_prefers_polkachu_https() {
+        let endpoints = vec![
+            chain::Grpc {
+                address: "http://insecure.example:9090".to_string(),
+                provider: Some("Insecure".to_string()),
+            },
+            chain::Grpc {
+                address: "community-grpc.example:443".to_string(),
+                provider: Some("Community".to_string()),
+            },
+            chain::Grpc {
+                address: "osmosis-grpc.polkachu.com:12590".to_string(),
+                provider: Some("Polkachu".to_string()),
+            },
+        ];
+
+        let prioritized = prioritize_grpc_endpoints(&endpoints);
+
+        assert_eq!(
+            prioritized,
+            vec![
+                "https://osmosis-grpc.polkachu.com:12590/".to_string(),
+                "https://community-grpc.example:443/".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_wallet_balance_formatting_separates_copyable_ibc_fields() {
+        let balances = vec![
+            WalletBalance {
+                balance: Balance {
+                    denom: "ibc/23B7FFE8D1673E1EBF05AB02000E23E6077967B79547A3733B60AE4ED62C4D32"
+                        .to_string(),
+                    amount: "10000000".to_string(),
+                },
+                ibc_trace: Some(IbcDenomTrace {
+                    path: "transfer/channel-123/transfer/channel-42".to_string(),
+                    base_denom: "loki".to_string(),
+                }),
+                asset_label: Some("LOKI".to_string()),
+            },
+            WalletBalance {
+                balance: Balance {
+                    denom: "factory/osmo1n6asrjy9754q8y9jsxqf557zmsv3s3xa5m9eg5/uspice".to_string(),
+                    amount: "999999".to_string(),
+                },
+                ibc_trace: None,
+                asset_label: Some("SPICE".to_string()),
+            },
+        ];
+
+        let formatted =
+            format_wallet_balances("osmo1wev8ptzj27aueu0abc", "osmosis", &balances, true);
+
+        assert!(formatted.contains("*Balances for* `osmo1wev8ptzj27aueu0...`"));
+        assert!(formatted.contains("*LOKI*"));
+        assert!(formatted.contains("Amount: `10,000,000`"));
+        assert!(formatted.contains(
+            "IBC Denom: `ibc/23B7FFE8D1673E1EBF05AB02000E23E6077967B79547A3733B60AE4ED62C4D32`"
+        ));
+        assert!(formatted.contains("IBC Path: `transfer/channel-123/transfer/channel-42`"));
+        assert!(formatted.contains("Base Denom: `loki`"));
+        assert!(formatted.contains("*SPICE*"));
+        assert!(formatted.contains("Amount: `999,999`"));
+        assert!(formatted
+            .contains("Denom: `factory/osmo1n6asrjy9754q8y9jsxqf557zmsv3s3xa5m9eg5/uspice`"));
+        assert!(formatted.contains("_Showing first 100 assets; more balances are available\\._"));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -231,17 +231,24 @@ pub async fn find_healthy_rest_endpoint(endpoints: &[chain::Rest]) -> Option<Str
 
 fn normalize_grpc_uri(address: &str) -> Option<String> {
     let address = address.trim().trim_end_matches('/');
-    if address.is_empty()
-        || address.starts_with("http://")
-        || (address.contains("://") && !address.starts_with("https://"))
-    {
+    if address.is_empty() {
         return None;
     }
 
-    if address.starts_with("https://") {
+    if address.starts_with("http://") || address.starts_with("https://") {
         Some(format!("{address}/"))
+    } else if address.contains("://") {
+        None
     } else {
-        Some(format!("https://{address}/"))
+        let lower = address.to_lowercase();
+        let explicit_port = address
+            .rsplit_once(':')
+            .map(|(_, port)| port)
+            .filter(|port| port.chars().all(|c| c.is_ascii_digit()));
+        let uses_tls = !lower.contains("polkachu.com")
+            && explicit_port.map(|port| port == "443").unwrap_or(true);
+        let scheme = if uses_tls { "https" } else { "http" };
+        Some(format!("{scheme}://{address}/"))
     }
 }
 
@@ -1224,7 +1231,11 @@ pub fn format_wallet_balances(
         escape_markdown(chain)
     );
 
-    for wallet_balance in balances {
+    for (index, wallet_balance) in balances.iter().enumerate() {
+        if index > 0 {
+            message.push_str("\n\n\\-\\-\\-");
+        }
+
         let label = display_asset_label(
             &wallet_balance.balance.denom,
             wallet_balance.ibc_trace.as_ref(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,36 @@
+use base64::{engine::general_purpose, Engine as _};
 use cosmos_chain_registry::chain;
+use cosmos_sdk_proto::cosmos::{
+    bank::v1beta1::{query_client::QueryClient as BankQueryClient, QueryAllBalancesRequest},
+    base::{
+        query::v1beta1::PageRequest,
+        tendermint::v1beta1::{
+            service_client::ServiceClient as TendermintServiceClient, GetLatestBlockRequest,
+            GetNodeInfoRequest,
+        },
+    },
+};
+use ibc_proto::ibc::{
+    applications::transfer::v1::{
+        query_client::QueryClient as TransferQueryClient, QueryDenomTraceRequest,
+    },
+    core::{
+        channel::v1::{
+            query_client::QueryClient as ChannelQueryClient, QueryChannelClientStateRequest,
+            QueryChannelRequest,
+        },
+        connection::v1::{
+            query_client::QueryClient as ConnectionQueryClient, QueryConnectionRequest,
+        },
+    },
+    lightclients::tendermint::v1::ClientState as TendermintClientState,
+};
+use prost::Message as _;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::time::Duration;
+use tonic::transport::{Channel, Endpoint};
 
 pub const PAGE_SIZE: usize = 18;
 
@@ -200,6 +229,48 @@ pub async fn find_healthy_rest_endpoint(endpoints: &[chain::Rest]) -> Option<Str
     None
 }
 
+fn normalize_grpc_uri(address: &str) -> Option<String> {
+    let address = address.trim().trim_end_matches('/');
+    if address.is_empty()
+        || address.starts_with("http://")
+        || (address.contains("://") && !address.starts_with("https://"))
+    {
+        return None;
+    }
+
+    if address.starts_with("https://") {
+        Some(format!("{address}/"))
+    } else {
+        Some(format!("https://{address}/"))
+    }
+}
+
+async fn connect_grpc(endpoint: &str) -> anyhow::Result<Channel> {
+    Ok(Endpoint::from_shared(endpoint.to_string())?
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(10))
+        .connect()
+        .await?)
+}
+
+pub async fn check_grpc_endpoint_health(endpoint: &str) -> bool {
+    let Ok(channel) = connect_grpc(endpoint).await else {
+        return false;
+    };
+
+    let mut client = TendermintServiceClient::new(channel);
+    client.get_node_info(GetNodeInfoRequest {}).await.is_ok()
+}
+
+pub async fn find_healthy_grpc_endpoint(endpoints: &[chain::Grpc]) -> Option<String> {
+    for endpoint in prioritize_grpc_endpoints(endpoints) {
+        if check_grpc_endpoint_health(&endpoint).await {
+            return Some(endpoint);
+        }
+    }
+    None
+}
+
 pub async fn query_ibc_denom(
     rest_endpoint: &str,
     ibc_hash: &str,
@@ -318,6 +389,51 @@ pub async fn query_ibc_denom_with_fallback(
     }
 
     Err(last_error.unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available")))
+}
+
+pub async fn query_ibc_denom_grpc(
+    grpc_endpoint: &str,
+    ibc_hash: &str,
+) -> anyhow::Result<IbcDenomTrace> {
+    let mut client = TransferQueryClient::new(connect_grpc(grpc_endpoint).await?);
+    let response = client
+        .denom_trace(QueryDenomTraceRequest {
+            hash: ibc_hash.to_string(),
+        })
+        .await?
+        .into_inner();
+    let trace = response
+        .denom_trace
+        .ok_or_else(|| anyhow::anyhow!("IBC denom trace not found"))?;
+
+    Ok(IbcDenomTrace {
+        path: trace.path,
+        base_denom: trace.base_denom,
+    })
+}
+
+pub async fn query_ibc_denom_grpc_first(
+    grpc_endpoints: &[chain::Grpc],
+    rest_endpoints: &[chain::Rest],
+    ibc_hash: &str,
+) -> anyhow::Result<IbcDenomTrace> {
+    let mut last_error = None;
+
+    for endpoint in prioritize_grpc_endpoints(grpc_endpoints).iter().take(3) {
+        log::info!("Trying gRPC endpoint for IBC denom trace: {}", endpoint);
+        match query_ibc_denom_grpc(endpoint, ibc_hash).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                log::warn!("Failed gRPC denom trace with endpoint {}: {}", endpoint, e);
+                last_error = Some(e);
+            }
+        }
+    }
+
+    match query_ibc_denom_with_fallback(rest_endpoints, ibc_hash).await {
+        Ok((path, base_denom)) => Ok(IbcDenomTrace { path, base_denom }),
+        Err(rest_error) => Err(last_error.unwrap_or(rest_error)),
+    }
 }
 
 pub async fn query_ibc_channel_info(
@@ -462,6 +578,136 @@ pub async fn query_ibc_channel_info_with_fallback(
         .unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available for channel query")))
 }
 
+fn decode_tendermint_client_chain_id(
+    client_state: &tendermint_proto::google::protobuf::Any,
+) -> anyhow::Result<String> {
+    if !client_state
+        .type_url
+        .ends_with("ibc.lightclients.tendermint.v1.ClientState")
+    {
+        return Err(anyhow::anyhow!(
+            "unsupported client state type {}",
+            client_state.type_url
+        ));
+    }
+
+    let client_state = TendermintClientState::decode(client_state.value.as_slice())?;
+    if client_state.chain_id.is_empty() {
+        return Err(anyhow::anyhow!("decoded client state missing chain ID"));
+    }
+    Ok(client_state.chain_id)
+}
+
+pub async fn query_ibc_channel_info_grpc(
+    grpc_endpoint: &str,
+    channel_id: &str,
+    port_id: &str,
+) -> anyhow::Result<IbcChannelInfo> {
+    let transport = connect_grpc(grpc_endpoint).await?;
+
+    let mut node_client = TendermintServiceClient::new(transport.clone());
+    let node_info = node_client
+        .get_node_info(GetNodeInfoRequest {})
+        .await?
+        .into_inner();
+    let chain_id = node_info
+        .default_node_info
+        .ok_or_else(|| anyhow::anyhow!("Chain node info not found"))?
+        .network;
+
+    let mut channel_client = ChannelQueryClient::new(transport.clone());
+    let channel_response = channel_client
+        .channel(QueryChannelRequest {
+            port_id: port_id.to_string(),
+            channel_id: channel_id.to_string(),
+        })
+        .await?
+        .into_inner();
+    let channel = channel_response
+        .channel
+        .ok_or_else(|| anyhow::anyhow!("Channel {} not found on port {}", channel_id, port_id))?;
+
+    let counterparty_channel_id = channel
+        .counterparty
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Counterparty channel not found"))?
+        .channel_id
+        .clone();
+
+    let connection_id = channel
+        .connection_hops
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("Connection ID not found"))?
+        .clone();
+
+    let mut connection_client = ConnectionQueryClient::new(transport);
+    let connection_response = connection_client
+        .connection(QueryConnectionRequest {
+            connection_id: connection_id.clone(),
+        })
+        .await?
+        .into_inner();
+    let connection = connection_response
+        .connection
+        .ok_or_else(|| anyhow::anyhow!("Connection {} not found", connection_id))?;
+
+    let client_id = connection.client_id.clone();
+    let counterparty = connection
+        .counterparty
+        .ok_or_else(|| anyhow::anyhow!("Counterparty connection not found"))?;
+
+    let client_state_response = channel_client
+        .channel_client_state(QueryChannelClientStateRequest {
+            port_id: port_id.to_string(),
+            channel_id: channel_id.to_string(),
+        })
+        .await?
+        .into_inner();
+    let identified_client_state = client_state_response
+        .identified_client_state
+        .ok_or_else(|| anyhow::anyhow!("Counterparty client state not found"))?;
+    let client_state = identified_client_state
+        .client_state
+        .ok_or_else(|| anyhow::anyhow!("Counterparty client state payload not found"))?;
+    let counterparty_chain_id = decode_tendermint_client_chain_id(&client_state)?;
+
+    Ok(IbcChannelInfo {
+        chain_id,
+        counterparty_chain_id,
+        client_id,
+        connection_id,
+        counterparty_client_id: counterparty.client_id,
+        counterparty_connection_id: counterparty.connection_id,
+        channel_id: channel_id.to_string(),
+        counterparty_channel_id,
+    })
+}
+
+pub async fn query_ibc_channel_info_grpc_first(
+    grpc_endpoints: &[chain::Grpc],
+    rest_endpoints: &[chain::Rest],
+    channel_id: &str,
+    port_id: &str,
+) -> anyhow::Result<IbcChannelInfo> {
+    let mut last_error = None;
+
+    for endpoint in prioritize_grpc_endpoints(grpc_endpoints).iter().take(3) {
+        log::info!("Trying gRPC endpoint for IBC channel info: {}", endpoint);
+        match query_ibc_channel_info_grpc(endpoint, channel_id, port_id).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                log::warn!("Failed gRPC channel info with endpoint {}: {}", endpoint, e);
+                last_error = Some(e);
+            }
+        }
+    }
+
+    match query_ibc_channel_info_with_fallback(rest_endpoints, channel_id, port_id).await {
+        Ok(result) => Ok(result),
+        Err(rest_error) => Err(last_error.unwrap_or(rest_error)),
+    }
+}
+
 pub fn extract_channel_from_path(path: &str) -> Option<String> {
     // Parse IBC path like "transfer/channel-23/transfer/channel-0"
     // We want to extract the first channel after "transfer/"
@@ -540,11 +786,77 @@ pub async fn query_abci_info(rpc_endpoint: &str) -> Option<AbciInfo> {
     })
 }
 
+fn bytes_to_upper_hex(bytes: &[u8]) -> String {
+    if bytes.is_empty() {
+        return "Unknown".to_string();
+    }
+
+    bytes.iter().map(|byte| format!("{byte:02X}")).collect()
+}
+
+pub async fn query_abci_info_grpc(grpc_endpoint: &str) -> Option<AbciInfo> {
+    let channel = connect_grpc(grpc_endpoint).await.ok()?;
+    let mut client = TendermintServiceClient::new(channel);
+
+    let node_info = client
+        .get_node_info(GetNodeInfoRequest {})
+        .await
+        .ok()?
+        .into_inner();
+    let version = node_info
+        .application_version
+        .map(|version| {
+            if !version.version.is_empty() {
+                version.version
+            } else if !version.cosmos_sdk_version.is_empty() {
+                version.cosmos_sdk_version
+            } else {
+                "Unknown".to_string()
+            }
+        })
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    let latest_block = client
+        .get_latest_block(GetLatestBlockRequest {})
+        .await
+        .ok()?
+        .into_inner();
+
+    if let Some(sdk_block) = latest_block.sdk_block {
+        let header = sdk_block.header?;
+        return Some(AbciInfo {
+            version,
+            last_block_height: header.height.to_string(),
+            last_block_app_hash: bytes_to_upper_hex(&header.app_hash),
+        });
+    }
+
+    let header = latest_block.block?.header?;
+    Some(AbciInfo {
+        version,
+        last_block_height: header.height.to_string(),
+        last_block_app_hash: bytes_to_upper_hex(&header.app_hash),
+    })
+}
+
 /// Balance entry from bank query
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Balance {
     pub denom: String,
     pub amount: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IbcDenomTrace {
+    pub path: String,
+    pub base_denom: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletBalance {
+    pub balance: Balance,
+    pub ibc_trace: Option<IbcDenomTrace>,
+    pub asset_label: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -715,6 +1027,49 @@ pub async fn query_balances(
     Ok((balances, next_key))
 }
 
+pub async fn query_balances_grpc(
+    grpc_endpoint: &str,
+    address: &str,
+    pagination_key: Option<&str>,
+) -> anyhow::Result<(Vec<Balance>, Option<String>)> {
+    let key = match pagination_key {
+        Some(key) => general_purpose::STANDARD.decode(key).unwrap_or_default(),
+        None => Vec::new(),
+    };
+
+    let mut client = BankQueryClient::new(connect_grpc(grpc_endpoint).await?);
+    let response = client
+        .all_balances(QueryAllBalancesRequest {
+            address: address.to_string(),
+            pagination: Some(PageRequest {
+                key,
+                offset: 0,
+                limit: 100,
+                count_total: false,
+                reverse: false,
+            }),
+            resolve_denom: false,
+        })
+        .await?
+        .into_inner();
+
+    let balances = response
+        .balances
+        .into_iter()
+        .map(|coin| Balance {
+            denom: coin.denom,
+            amount: coin.amount,
+        })
+        .collect();
+
+    let next_key = response
+        .pagination
+        .and_then(|pagination| (!pagination.next_key.is_empty()).then_some(pagination.next_key))
+        .map(|next_key| general_purpose::STANDARD.encode(next_key));
+
+    Ok((balances, next_key))
+}
+
 /// Query balances with fallback to multiple REST endpoints
 pub async fn query_balances_with_fallback(
     endpoints: &[chain::Rest],
@@ -745,6 +1100,35 @@ pub async fn query_balances_with_fallback(
         .unwrap_or_else(|| anyhow::anyhow!("No valid REST endpoints available for balance query")))
 }
 
+pub async fn query_balances_grpc_first(
+    grpc_endpoints: &[chain::Grpc],
+    rest_endpoints: &[chain::Rest],
+    address: &str,
+    pagination_key: Option<&str>,
+) -> anyhow::Result<(Vec<Balance>, Option<String>)> {
+    let mut last_error = None;
+
+    for endpoint in prioritize_grpc_endpoints(grpc_endpoints).iter().take(3) {
+        log::info!("Trying gRPC endpoint for balances: {}", endpoint);
+        match query_balances_grpc(endpoint, address, pagination_key).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                log::warn!(
+                    "Failed gRPC balance query with endpoint {}: {}",
+                    endpoint,
+                    e
+                );
+                last_error = Some(e);
+            }
+        }
+    }
+
+    match query_balances_with_fallback(rest_endpoints, address, pagination_key).await {
+        Ok(result) => Ok(result),
+        Err(rest_error) => Err(last_error.unwrap_or(rest_error)),
+    }
+}
+
 /// Format amount with thousands separators
 pub fn format_amount(amount: &str) -> String {
     // Parse the amount string as a number and format with commas
@@ -770,6 +1154,108 @@ pub fn truncate_ibc_hash(hash: &str) -> String {
     } else {
         hash.to_string()
     }
+}
+
+pub fn prioritize_grpc_endpoints(endpoints: &[chain::Grpc]) -> Vec<String> {
+    let mut polkachu = Vec::new();
+    let mut others = Vec::new();
+
+    for endpoint in endpoints {
+        let Some(uri) = normalize_grpc_uri(&endpoint.address) else {
+            continue;
+        };
+
+        let is_polkachu = endpoint
+            .provider
+            .as_deref()
+            .unwrap_or_default()
+            .to_lowercase()
+            .contains("polkachu")
+            || endpoint.address.to_lowercase().contains("polkachu.com");
+
+        if is_polkachu {
+            polkachu.push(uri);
+        } else {
+            others.push(uri);
+        }
+    }
+
+    polkachu.extend(others);
+    polkachu
+}
+
+fn escape_markdown_code(text: &str) -> String {
+    text.replace('\\', "\\\\").replace('`', "\\`")
+}
+
+fn display_asset_label(
+    denom: &str,
+    trace: Option<&IbcDenomTrace>,
+    asset_label: Option<&str>,
+) -> String {
+    if let Some(asset_label) = asset_label.filter(|label| !label.is_empty()) {
+        return asset_label.to_string();
+    }
+
+    let display = trace.map(|t| t.base_denom.as_str()).unwrap_or(denom);
+    display
+        .rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or(display)
+        .to_string()
+}
+
+pub fn format_wallet_balances(
+    address: &str,
+    chain: &str,
+    balances: &[WalletBalance],
+    more_available: bool,
+) -> String {
+    let display_address = if address.len() > 20 {
+        format!("{}...", &address[..20])
+    } else {
+        address.to_string()
+    };
+
+    let mut message = format!(
+        "💰 *Balances for* `{}` on *{}*",
+        escape_markdown_code(&display_address),
+        escape_markdown(chain)
+    );
+
+    for wallet_balance in balances {
+        let label = display_asset_label(
+            &wallet_balance.balance.denom,
+            wallet_balance.ibc_trace.as_ref(),
+            wallet_balance.asset_label.as_deref(),
+        );
+        message.push_str(&format!(
+            "\n\n*{}*\nAmount: `{}`",
+            escape_markdown(&label),
+            escape_markdown_code(&format_amount(&wallet_balance.balance.amount))
+        ));
+
+        if let Some(trace) = &wallet_balance.ibc_trace {
+            message.push_str(&format!(
+                "\nIBC Denom: `{}`\nIBC Path: `{}`\nBase Denom: `{}`",
+                escape_markdown_code(&wallet_balance.balance.denom),
+                escape_markdown_code(&trace.path),
+                escape_markdown_code(&trace.base_denom)
+            ));
+        } else {
+            message.push_str(&format!(
+                "\nDenom: `{}`",
+                escape_markdown_code(&wallet_balance.balance.denom)
+            ));
+        }
+    }
+
+    if more_available {
+        message.push_str("\n\n_Showing first 100 assets; more balances are available\\._");
+    }
+
+    message
 }
 
 pub async fn query_osmosis_pool_info(


### PR DESCRIPTION
## Summary
- adds Cosmos SDK and IBC gRPC clients with Polkachu-prioritized endpoint selection
- uses gRPC first for wallet balances, IBC denom traces, IBC route lookup, and chain status, with REST/RPC fallback where needed
- supports plaintext Polkachu/custom-port gRPC endpoints instead of incorrectly forcing TLS
- adds Telegram processing indicators and editable status messages for longer bot requests
- reformats wallet balances into separated per-asset Markdown blocks with pretty labels, amounts, full copyable denoms, IBC paths, and base denoms
- updates docs for the gRPC-first query path and switches the systemd unit from deprecated `MemoryLimit` to `MemoryMax`

## Validation
- `./scripts/check.sh`
- `./scripts/build.sh --skip-checks`
- `grpcurl -plaintext -d '{}' osmosis-grpc.polkachu.com:12590 cosmos.base.tendermint.v1beta1.Service/GetNodeInfo`
- `grpcurl -plaintext -d '{"hash":"D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"}' osmosis-grpc.polkachu.com:12590 ibc.applications.transfer.v1.Query/DenomTrace`
- `grpcurl -plaintext -d '{"address":"osmo1n6asrjy9754q8y9jsxqf557zmsv3s3xa5m9eg5","pagination":{"limit":"3"},"resolveDenom":false}' osmosis-grpc.polkachu.com:12590 cosmos.bank.v1beta1.Query/AllBalances`
