### PR TITLE
[codex] add build and deploy automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust:
+    name: rust checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo build outputs
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run lint, type, and test gates
+        run: ./scripts/check.sh
+
+      - name: Build release binary
+        run: ./scripts/build.sh --skip-checks

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: LXC container name on the self-hosted runner
+        required: true
+        default: tgbot
+      service:
+        description: systemd unit name
+        required: true
+        default: cosmoclerk.service
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy:
+    name: deploy to LXC
+    runs-on: self-hosted
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Deploy
+        env:
+          DEPLOY_TARGET: ${{ inputs.target }}
+          DEPLOY_SERVICE: ${{ inputs.service }}
+        run: ./scripts/deploy.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,12 @@ CosmoClerk is a Rust 2021 Telegram bot for Cosmos chain-registry lookups. Source
 
 ## Build, Test, and Development Commands
 - `cp .env.example .env` then set `BOT_TOKEN` before running locally.
-- `cargo check` validates Rust types quickly.
+- `./scripts/check.sh` runs the local pre-build gate: `cargo fmt -- --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
+- `./scripts/build.sh` runs the pre-build gate, then creates `target/release/cosmoclerk`.
+- `./scripts/build.sh --skip-checks` creates the release binary after checks have already passed.
+- `DEPLOY_TARGET=tgbot ./scripts/deploy.sh` builds, installs the binary and systemd unit into the LXC target, restarts the service, and prints recent logs.
+- `cargo check` validates Rust types quickly when a narrower loop is useful.
 - `RUST_LOG=debug cargo run` starts the bot with verbose logging.
-- `cargo build --release` creates `target/release/cosmoclerk` for deployment.
 - `cargo test` runs the async unit tests in `src/tests.rs`.
 - `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` are the preferred pre-PR style and lint gates.
 

--- a/README_RUST.md
+++ b/README_RUST.md
@@ -51,14 +51,11 @@ cargo run --release
 # Run with debug logging
 RUST_LOG=debug cargo run
 
-# Check code
-cargo check
+# Run the full local pre-build gate
+./scripts/check.sh
 
-# Run tests
-cargo test
-
-# Format code
-cargo fmt
+# Build with pre-build checks
+./scripts/build.sh
 ```
 
 ## Architecture
@@ -82,12 +79,22 @@ Legacy JavaScript/TypeScript versions are archived on isolated branches. The act
 
 ## Deployment
 
-The compiled binary is self-contained and can be deployed anywhere:
+The compiled binary is self-contained and can be deployed anywhere. For the
+standard systemd/LXC deployment used by this repo, keep the bot token in
+`/etc/cosmoclerk/.env` on the target and run:
 
 ```bash
-cargo build --release
-cp target/release/cosmoclerk /path/to/deployment/
+DEPLOY_TARGET=tgbot ./scripts/deploy.sh
 ```
+
+`scripts/deploy.sh` builds the release binary, pushes it to
+`/usr/local/bin/cosmoclerk`, installs `cosmoclerk.service`, restarts the service,
+checks that it is active, and prints recent logs. It does not copy `.env` or any
+secret material.
+
+For a generic host, run `./scripts/build.sh` and copy
+`target/release/cosmoclerk` plus `cosmoclerk.service` using your host's release
+process.
 
 ## Docker
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+skip_checks=0
+if [[ "${1:-}" == "--skip-checks" ]]; then
+  skip_checks=1
+elif [[ $# -gt 0 ]]; then
+  echo "usage: $0 [--skip-checks]" >&2
+  exit 2
+fi
+
+if [[ "$skip_checks" -eq 0 ]]; then
+  ./scripts/check.sh
+fi
+
+echo "==> cargo build --release"
+cargo build --release
+
+binary="$repo_root/target/release/cosmoclerk"
+if [[ ! -x "$binary" ]]; then
+  echo "release binary was not created at $binary" >&2
+  exit 1
+fi
+
+echo "Built $binary"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> cargo fmt -- --check"
+cargo fmt -- --check
+
+echo "==> cargo check"
+cargo check
+
+echo "==> cargo clippy --all-targets -- -D warnings"
+cargo clippy --all-targets -- -D warnings
+
+echo "==> cargo test"
+cargo test

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+target="${DEPLOY_TARGET:-tgbot}"
+unit="${DEPLOY_SERVICE:-cosmoclerk.service}"
+remote_binary="${DEPLOY_BINARY:-/usr/local/bin/cosmoclerk}"
+remote_binary_dir="${remote_binary%/*}"
+remote_workdir="${DEPLOY_WORKDIR:-/etc/cosmoclerk}"
+remote_env="${DEPLOY_ENV_FILE:-$remote_workdir/.env}"
+run_user="${DEPLOY_USER:-cosmoclerk}"
+run_group="${DEPLOY_GROUP:-cosmoclerk}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd lxc
+require_cmd install
+
+./scripts/build.sh
+
+tmp_binary="/tmp/cosmoclerk.$$"
+tmp_service="/tmp/${unit}.$$"
+
+cleanup() {
+  lxc exec "$target" -- rm -f "$tmp_binary" "$tmp_service" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> verifying target $target"
+lxc exec "$target" -- true
+
+echo "==> ensuring runtime user and directories"
+lxc exec "$target" -- sh -c "getent group '$run_group' >/dev/null || groupadd --system '$run_group'"
+lxc exec "$target" -- sh -c "id -u '$run_user' >/dev/null 2>&1 || useradd --system --gid '$run_group' --home-dir '$remote_workdir' --shell /usr/sbin/nologin '$run_user'"
+lxc exec "$target" -- mkdir -p "$remote_binary_dir" "$remote_workdir"
+lxc exec "$target" -- chown "$run_user:$run_group" "$remote_workdir"
+
+echo "==> verifying runtime env file $remote_env"
+if ! lxc exec "$target" -- test -f "$remote_env"; then
+  echo "target is missing $remote_env; create it with BOT_TOKEN before deploying" >&2
+  exit 1
+fi
+
+echo "==> pushing release binary and systemd unit"
+lxc file push target/release/cosmoclerk "$target$tmp_binary"
+lxc file push cosmoclerk.service "$target$tmp_service"
+
+echo "==> installing binary to $remote_binary"
+lxc exec "$target" -- install -o root -g root -m 0755 "$tmp_binary" "$remote_binary"
+
+echo "==> installing systemd unit /etc/systemd/system/$unit"
+lxc exec "$target" -- install -o root -g root -m 0644 "$tmp_service" "/etc/systemd/system/$unit"
+
+echo "==> restarting $unit"
+lxc exec "$target" -- systemctl daemon-reload
+lxc exec "$target" -- systemctl enable "$unit"
+lxc exec "$target" -- systemctl restart "$unit"
+lxc exec "$target" -- systemctl is-active --quiet "$unit"
+
+echo "==> recent service logs"
+lxc exec "$target" -- journalctl -u "$unit" -n 30 --no-pager
+
+echo "Deployment complete on $target"


### PR DESCRIPTION
## Summary
- adds reusable local gates for formatting, type checking, clippy, tests, and release builds
- adds a guarded LXC/systemd deploy script for the standard `tgbot` deployment path
- adds GitHub Actions for PR/main CI and manual production deployment from a self-hosted runner
- updates contributor and Rust docs to point at the scripted workflow

## Validation
- `bash -n scripts/check.sh`
- `bash -n scripts/build.sh`
- `bash -n scripts/deploy.sh`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .github/workflows/ci.yml .github/workflows/deploy.yml`
- `git diff --check`
- `./scripts/check.sh`
- `./scripts/build.sh --skip-checks`

## Notes
- `scripts/deploy.sh` does not copy `.env` or secrets. The target must already have `/etc/cosmoclerk/.env` with `BOT_TOKEN`.
- The deploy workflow is manual and expects a self-hosted runner with `lxc` access.
- `actionlint` was not installed locally, so workflow validation was syntax parsing plus script execution.
